### PR TITLE
Update BaseApiClient to check connector status

### DIFF
--- a/src/main/java/com/czertainly/api/clients/AttributeApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/AttributeApiClient.java
@@ -31,7 +31,7 @@ public class AttributeApiClient extends BaseApiClient {
     }
 
     public List<AttributeDefinition> listAttributeDefinitions(ConnectorDto connector, FunctionGroupCode functionGroupCode, String kind) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ATTRIBUTE_BASE_CONTEXT, functionGroupCode.getCode(), kind)
@@ -43,7 +43,7 @@ public class AttributeApiClient extends BaseApiClient {
     }
 
     public Void validateAttributes(ConnectorDto connector, FunctionGroupCode functionGroupCode, List<RequestAttributeDto> attributes, String functionGroupType) throws ValidationException, ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ATTRIBUTE_VALIDATION_CONTEXT, functionGroupCode.getCode(), functionGroupType)
@@ -75,7 +75,7 @@ public class AttributeApiClient extends BaseApiClient {
         }
 
         WebClient.RequestBodySpec request =
-                prepareRequest(method, connector.getAuthType(), connector.getAuthAttributes())
+                prepareRequest(method, connector, true)
                         .uri(uri);
 
         if (callbackRequest.getRequestBody() != null) {

--- a/src/main/java/com/czertainly/api/clients/AuthorityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/AuthorityInstanceApiClient.java
@@ -29,7 +29,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
     public List<AuthorityProviderInstanceDto> listAuthorityInstances(ConnectorDto connector) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_BASE_CONTEXT)
@@ -41,7 +41,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
     public AuthorityProviderInstanceDto getAuthorityInstance(ConnectorDto connector, String uuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -53,7 +53,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
     public AuthorityProviderInstanceDto createAuthorityInstance(ConnectorDto connector, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_BASE_CONTEXT)
@@ -67,7 +67,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
 
 
     public AuthorityProviderInstanceDto updateAuthorityInstance(ConnectorDto connector, String uuid, AuthorityProviderInstanceRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -80,7 +80,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
     public void removeAuthorityInstance(ConnectorDto connector, String uuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_IDENTIFIED_CONTEXT, uuid)
@@ -93,7 +93,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
 
 
     public List<AttributeDefinition> listRAProfileAttributes(ConnectorDto connector, String uuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_RA_ATTRS_CONTEXT, uuid)
@@ -105,7 +105,7 @@ public class AuthorityInstanceApiClient extends BaseApiClient {
     }
 
     public Boolean validateRAProfileAttributes(ConnectorDto connector, String uuid, List<RequestAttributeDto> attributes) throws ValidationException, ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + AUTHORITY_INSTANCE_RA_ATTRS_VALIDATE_CONTEXT, uuid)

--- a/src/main/java/com/czertainly/api/clients/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/CertificateApiClient.java
@@ -20,7 +20,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public CertificateSignResponseDto issueCertificate(ConnectorDto connector, String authorityUuid, String endEntityProfileName, CertificateSignRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_ISSUE_CONTEXT, authorityUuid, endEntityProfileName)
@@ -33,7 +33,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public void revokeCertificate(ConnectorDto connector, String authorityUuid, String endEntityProfileName, CertRevocationDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_CONTEXT, authorityUuid, endEntityProfileName)

--- a/src/main/java/com/czertainly/api/clients/ComplianceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/ComplianceApiClient.java
@@ -5,9 +5,6 @@ import com.czertainly.api.model.connector.compliance.ComplianceGroupsResponseDto
 import com.czertainly.api.model.connector.compliance.ComplianceRequestDto;
 import com.czertainly.api.model.connector.compliance.ComplianceResponseDto;
 import com.czertainly.api.model.connector.compliance.ComplianceRulesResponseDto;
-import com.czertainly.api.model.connector.discovery.DiscoveryDataRequestDto;
-import com.czertainly.api.model.connector.discovery.DiscoveryProviderDto;
-import com.czertainly.api.model.connector.discovery.DiscoveryRequestDto;
 import com.czertainly.api.model.core.connector.ConnectorDto;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -44,7 +41,7 @@ public class ComplianceApiClient extends BaseApiClient {
                     .forEach(q -> uriBuilder.queryParam(CERTIFICATE_TYPE_QUERY_HEADER, q));
         }
         uri = uriBuilder.build();
-        WebClient.RequestBodySpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes()).uri(uri);
+        WebClient.RequestBodySpec request = prepareRequest(HttpMethod.GET, connector, true).uri(uri);
 
         return processRequest(r -> r
                 .retrieve()
@@ -56,7 +53,7 @@ public class ComplianceApiClient extends BaseApiClient {
 
 
     public List<ComplianceGroupsResponseDto> getComplianceGroups(ConnectorDto connector, String kind) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                         .uri(connector.getUrl() + COMPLIANCE_GROUP_GET_CONTEXT, kind)
@@ -69,7 +66,7 @@ public class ComplianceApiClient extends BaseApiClient {
 
 
     public List<ComplianceRulesResponseDto> getComplianceGroupRules(ConnectorDto connector, String kind, String uuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                         .uri(connector.getUrl() + COMPLIANCE_GROUP_RULE_CONTEXT, kind, uuid)
@@ -81,7 +78,7 @@ public class ComplianceApiClient extends BaseApiClient {
     }
 
     public ComplianceResponseDto checkCompliance(ConnectorDto connector, String kind, ComplianceRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                         .uri(connector.getUrl() + COMPLIANCE_CONTEXT, kind)

--- a/src/main/java/com/czertainly/api/clients/ConnectorApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/ConnectorApiClient.java
@@ -21,13 +21,13 @@ public class ConnectorApiClient extends BaseApiClient {
     }
 
     public List<InfoResponse> listSupportedFunctions(ConnectorDto connector) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 
         return processRequest(r -> r
-                .uri(connector.getUrl() + CONNECTOR_BASE_CONTEXT)
-                .retrieve()
-                .toEntity(MAP_TYPE_REF)
-                .block().getBody(),
+                        .uri(connector.getUrl() + CONNECTOR_BASE_CONTEXT)
+                        .retrieve()
+                        .toEntity(MAP_TYPE_REF)
+                        .block().getBody(),
                 request,
                 connector);
     }

--- a/src/main/java/com/czertainly/api/clients/DiscoveryApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/DiscoveryApiClient.java
@@ -20,7 +20,7 @@ public class DiscoveryApiClient extends BaseApiClient {
 
 
     public DiscoveryProviderDto discoverCertificates(ConnectorDto connector, DiscoveryRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + DISCOVERY_BASE_CONTEXT)
@@ -33,7 +33,7 @@ public class DiscoveryApiClient extends BaseApiClient {
     }
 
     public DiscoveryProviderDto getDiscoveryData(ConnectorDto connector, DiscoveryDataRequestDto requestDto, String uuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                         .uri(connector.getUrl() + DISCOVERY_GET_CONTEXT, uuid)

--- a/src/main/java/com/czertainly/api/clients/EndEntityApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EndEntityApiClient.java
@@ -22,7 +22,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public List<EndEntityDto> listEntities(ConnectorDto connector, String authorityUuid, String endEntityProfileName) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_BASE_CONTEXT, authorityUuid, endEntityProfileName)
@@ -34,7 +34,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public EndEntityDto getEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_IDENTIFIED_CONTEXT, authorityUuid, endEntityProfileName, endEntityName)
@@ -46,7 +46,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public void createEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, AddEndEntityRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_BASE_CONTEXT, authorityUuid, endEntityProfileName)
@@ -59,7 +59,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public void updateEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName, EditEndEntityRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_IDENTIFIED_CONTEXT, authorityUuid, endEntityProfileName, endEntityName)
@@ -72,7 +72,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public void revokeAndDeleteEndEntity(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_IDENTIFIED_CONTEXT, authorityUuid, endEntityProfileName, endEntityName)
@@ -84,7 +84,7 @@ public class EndEntityApiClient extends BaseApiClient {
     }
 
     public void resetPassword(ConnectorDto connector, String authorityUuid, String endEntityProfileName, String endEntityName) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_RESET_PASSWORD_CONTEXT, authorityUuid, endEntityProfileName, endEntityName)

--- a/src/main/java/com/czertainly/api/clients/EndEntityProfileApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EndEntityProfileApiClient.java
@@ -20,7 +20,7 @@ public class EndEntityProfileApiClient extends BaseApiClient {
     }
 
     public List<NameAndIdDto> listEndEntityProfiles(ConnectorDto connector, String authorityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_PROFILE_BASE_CONTEXT, authorityUuid)
@@ -32,7 +32,7 @@ public class EndEntityProfileApiClient extends BaseApiClient {
     }
 
     public List<NameAndIdDto> listCertificateProfiles(ConnectorDto connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_PROFILE_CERT_PROFILE_CONTEXT, authorityUuid, endEntityProfileId)
@@ -44,7 +44,7 @@ public class EndEntityProfileApiClient extends BaseApiClient {
     }
 
     public List<NameAndIdDto> listCAsInProfile(ConnectorDto connector, String authorityUuid, int endEntityProfileId) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + END_ENTITY_PROFILE_CAS_IN_PROFILE_CONTEXT, authorityUuid, endEntityProfileId)

--- a/src/main/java/com/czertainly/api/clients/EntityInstanceApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/EntityInstanceApiClient.java
@@ -29,7 +29,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public List<EntityInstanceDto> listEntityInstances(ConnectorDto connector) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_BASE_CONTEXT)
@@ -41,7 +41,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public EntityInstanceDto getEntityInstance(ConnectorDto connector, String entityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_IDENTIFIED_CONTEXT, entityUuid)
@@ -53,7 +53,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public EntityInstanceDto createEntityInstance(ConnectorDto connector, EntityInstanceRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_BASE_CONTEXT)
@@ -66,7 +66,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public EntityInstanceDto updateEntityInstance(ConnectorDto connector, String entityUuid, EntityInstanceRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.PUT, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_IDENTIFIED_CONTEXT, entityUuid)
@@ -79,7 +79,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public void removeEntityInstance(ConnectorDto connector, String entityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.DELETE, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_IDENTIFIED_CONTEXT, entityUuid)
@@ -92,7 +92,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
 
 
     public List<AttributeDefinition> listLocationAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_LOCATION_ATTRS_CONTEXT, entityUuid)
@@ -104,7 +104,7 @@ public class EntityInstanceApiClient extends BaseApiClient {
     }
 
     public void validateLocationAttributes(ConnectorDto connector, String entityUuid, List<RequestAttributeDto> attributes) throws ValidationException, ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + ENTITY_INSTANCE_LOCATION_ATTRS_VALIDATE_CONTEXT, entityUuid)

--- a/src/main/java/com/czertainly/api/clients/HealthApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/HealthApiClient.java
@@ -15,7 +15,7 @@ public class HealthApiClient extends BaseApiClient {
     }
 
     public HealthDto checkHealth(ConnectorDto connector) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, false);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + HEALTH_BASE_CONTEXT)

--- a/src/main/java/com/czertainly/api/clients/LocationApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/LocationApiClient.java
@@ -31,7 +31,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public LocationDetailResponseDto getLocationDetail(ConnectorDto connector, String entityUuid, LocationDetailRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_BASE_CONTEXT, entityUuid)
@@ -44,7 +44,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public PushCertificateResponseDto pushCertificateToLocation(ConnectorDto connector, String entityUuid, PushCertificateRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_PUSH_CONTEXT, entityUuid)
@@ -57,7 +57,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public List<AttributeDefinition> listPushCertificateAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_PUSH_ATTRS_CONTEXT, entityUuid)
@@ -69,7 +69,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public void validatePushCertificateAttributes(ConnectorDto connector, String entityUuid, List<RequestAttributeDto> pushAttributes) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_PUSH_ATTRS_VALIDATE_CONTEXT, entityUuid)
@@ -82,7 +82,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public RemoveCertificateResponseDto removeCertificateFromLocation(ConnectorDto connector, String entityUuid, RemoveCertificateRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_REMOVE_CONTEXT, entityUuid)
@@ -95,7 +95,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public GenerateCsrResponseDto generateCsrLocation(ConnectorDto connector, String entityUuid, GenerateCsrRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_CSR_CONTEXT, entityUuid)
@@ -108,7 +108,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public List<AttributeDefinition> listGenerateCsrAttributes(ConnectorDto connector, String entityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_CSR_ATTRS_CONTEXT, entityUuid)
@@ -120,7 +120,7 @@ public class LocationApiClient extends BaseApiClient {
     }
 
     public void validateGenerateCsrAttributes(ConnectorDto connector, String entityUuid, List<RequestAttributeDto> pushAttributes) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + LOCATION_CSR_ATTRS_VALIDATE_CONTEXT, entityUuid)

--- a/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
+++ b/src/main/java/com/czertainly/api/clients/v2/CertificateApiClient.java
@@ -40,7 +40,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public List<AttributeDefinition> listIssueCertificateAttributes(ConnectorDto connector, String authorityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_ISSUE_ATTRIBUTES_CONTEXT, authorityUuid)
@@ -52,7 +52,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public Boolean validateIssueCertificateAttributes(ConnectorDto connector, String authorityUuid, List<RequestAttributeDto> attributes) throws ValidationException, ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_ISSUE_ATTRIBUTES_VALIDATE_CONTEXT, authorityUuid)
@@ -65,7 +65,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public CertificateDataResponseDto issueCertificate(ConnectorDto connector, String authorityUuid, CertificateSignRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_ISSUE_CONTEXT, authorityUuid)
@@ -78,7 +78,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public CertificateDataResponseDto renewCertificate(ConnectorDto connector, String authorityUuid, CertificateRenewRequestDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_RENEW_CONTEXT, authorityUuid)
@@ -91,7 +91,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public List<AttributeDefinition> listRevokeCertificateAttributes(ConnectorDto connector, String authorityUuid) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.GET, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_ATTRIBUTES_CONTEXT, authorityUuid)
@@ -103,7 +103,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public Boolean validateRevokeCertificateAttributes(ConnectorDto connector, String authorityUuid, List<RequestAttributeDto> attributes) throws ValidationException, ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         return processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_ATTRIBUTES_VALIDATE_CONTEXT, authorityUuid)
@@ -116,7 +116,7 @@ public class CertificateApiClient extends BaseApiClient {
     }
 
     public void revokeCertificate(ConnectorDto connector, String authorityUuid, CertRevocationDto requestDto) throws ConnectorException {
-        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector.getAuthType(), connector.getAuthAttributes());
+        WebClient.RequestBodyUriSpec request = prepareRequest(HttpMethod.POST, connector, true);
 
         processRequest(r -> r
                 .uri(connector.getUrl() + CERTIFICATE_REVOKE_CONTEXT, authorityUuid)

--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorStatus.java
@@ -11,10 +11,7 @@ import java.util.Arrays;
 public enum ConnectorStatus {
 
     WAITING_FOR_APPROVAL("waitingForApproval"),
-    REGISTERED("registered"),
     CONNECTED("connected"),
-    UNAVAILABLE("unavailable"),
-    MISCONFIGURED("misconfigured"),
     FAILED("failed"),
     OFFLINE("offline")
     ;

--- a/src/test/java/com/czertainly/api/ApiClientTest.java
+++ b/src/test/java/com/czertainly/api/ApiClientTest.java
@@ -21,6 +21,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 
 import java.net.ConnectException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 
 public class ApiClientTest {
 
@@ -169,9 +170,10 @@ public class ApiClientTest {
         connector.setUrl("localhost:3665");
         connector.setStatus(ConnectorStatus.WAITING_FOR_APPROVAL);
 
-        Assertions.assertThrows(ValidationException.class, () -> attributeApiClient.listAttributeDefinitions(
+        Assertions.assertThrows(ValidationException.class, () -> attributeApiClient.validateAttributes(
                 connector,
                 FunctionGroupCode.CREDENTIAL_PROVIDER,
+                new ArrayList<>(),
                 "certificate"));
     }
 }

--- a/src/test/java/com/czertainly/api/ApiClientTest.java
+++ b/src/test/java/com/czertainly/api/ApiClientTest.java
@@ -6,7 +6,9 @@ import com.czertainly.api.exception.ConnectorClientException;
 import com.czertainly.api.exception.ConnectorCommunicationException;
 import com.czertainly.api.exception.ConnectorServerException;
 import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.exception.ValidationException;
 import com.czertainly.api.model.core.connector.ConnectorDto;
+import com.czertainly.api.model.core.connector.ConnectorStatus;
 import com.czertainly.api.model.core.connector.FunctionGroupCode;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -45,6 +47,7 @@ public class ApiClientTest {
     public void testGetAttributes_unknownHost() {
         ConnectorDto connector = new ConnectorDto();
         connector.setUrl("wrong-host:1234");
+        connector.setStatus(ConnectorStatus.CONNECTED);
 
         Throwable cause = Assertions.assertThrows(ConnectorCommunicationException.class, () ->
             // tested method
@@ -63,6 +66,7 @@ public class ApiClientTest {
     public void testGetAttributes_connectionRefused() {
         ConnectorDto connector = new ConnectorDto();
         connector.setUrl("localhost:1234");
+        connector.setStatus(ConnectorStatus.CONNECTED);
 
         Throwable cause = Assertions.assertThrows(ConnectorCommunicationException.class, () ->
                 // tested method
@@ -89,6 +93,7 @@ public class ApiClientTest {
 
         ConnectorDto connector = new ConnectorDto();
         connector.setUrl("localhost:3665");
+        connector.setStatus(ConnectorStatus.CONNECTED);
 
         NotFoundException cause = Assertions.assertThrows(NotFoundException.class, () ->
                 // tested method
@@ -114,6 +119,7 @@ public class ApiClientTest {
 
         ConnectorDto connector = new ConnectorDto();
         connector.setUrl("localhost:3665");
+        connector.setStatus(ConnectorStatus.CONNECTED);
 
         ConnectorClientException cause = Assertions.assertThrows(ConnectorClientException.class, () ->
                 // tested method
@@ -140,6 +146,7 @@ public class ApiClientTest {
 
         ConnectorDto connector = new ConnectorDto();
         connector.setUrl("localhost:3665");
+        connector.setStatus(ConnectorStatus.CONNECTED);
 
         ConnectorServerException cause = Assertions.assertThrows(ConnectorServerException.class, () ->
                 // tested method
@@ -152,5 +159,19 @@ public class ApiClientTest {
         Assertions.assertEquals(bodyString, cause.getMessage());
         Assertions.assertEquals(connector, cause.getConnector());
         Assertions.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, cause.getHttpStatus());
+    }
+
+
+    @Test
+    public void testGetAttributes_waitingForApproval() {
+
+        ConnectorDto connector = new ConnectorDto();
+        connector.setUrl("localhost:3665");
+        connector.setStatus(ConnectorStatus.WAITING_FOR_APPROVAL);
+
+        Assertions.assertThrows(ValidationException.class, () -> attributeApiClient.listAttributeDefinitions(
+                connector,
+                FunctionGroupCode.CREDENTIAL_PROVIDER,
+                "certificate"));
     }
 }


### PR DESCRIPTION
When the BaseApiClient is initiating the connection to the connector, a new method is added that will check for the status of the connector. If the connector status is not Waiting for approval, then it lets the request throw. Else a validation exception will be thrown.