### PR TITLE
Equals and Hashcode functions for Attribute Contents

### DIFF
--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/AttributeContentType.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/AttributeContentType.java
@@ -12,28 +12,24 @@ import java.util.Arrays;
 @Schema(enumAsRef = true)
 public enum AttributeContentType {
 
-	STRING(Constants.STRING),
+    STRING(Constants.STRING),
     INTEGER(Constants.INTEGER),
-	SECRET(Constants.SECRET),
-	FILE(Constants.FILE),
-	BOOLEAN(Constants.BOOLEAN),
+    SECRET(Constants.SECRET),
+    FILE(Constants.FILE),
+    BOOLEAN(Constants.BOOLEAN),
     CREDENTIAL(Constants.CREDENTIAL),
     DATE(Constants.DATE),
     FLOAT(Constants.FLOAT),
     OBJECT(Constants.OBJECT),
     TEXT(Constants.TEXT),
     TIME(Constants.TIME),
-    DATETIME(Constants.DATETIME),;
+    DATETIME(Constants.DATETIME),
+    ;
 
     private final String code;
 
     AttributeContentType(String string) {
         this.code = string;
-    }
-
-    @JsonValue
-    public String getCode() {
-        return code;
     }
 
     @JsonCreator
@@ -47,55 +43,97 @@ public enum AttributeContentType {
     public static Class getClass(AttributeContentType code) {
         switch (code) {
             case STRING:
-            case SECRET:
             case TEXT:
-                return String.class;
+                return StringAttributeContent.class;
+            case SECRET:
+                return SecretAttributeContent.class;
             case INTEGER:
-                return Integer.class;
+                return IntegerAttributeContent.class;
             case BOOLEAN:
-                return Boolean.class;
+                return BooleanAttributeContent.class;
             case FLOAT:
-                return Float.class;
+                return FloatAttributeContent.class;
+            case CREDENTIAL:
+                return CredentialAttributeContent.class;
+            case DATE:
+                return DateAttributeContent.class;
+            case DATETIME:
+                return DateTimeAttributeContent.class;
+            case FILE:
+                return FileAttributeContent.class;
+            case OBJECT:
+                return ObjectAttributeContent.class;
+            case TIME:
+                return TimeAttributeContent.class;
             default:
                 return null;
         }
     }
-    
+
+    @JsonValue
+    public String getCode() {
+        return code;
+    }
+
     private static class Constants {
-    	/** Simple text Attribute **/
+        /**
+         * Simple text Attribute
+         **/
         private static final String STRING = "string";
 
-        /** Simple integer Attribute **/
+        /**
+         * Simple integer Attribute
+         **/
         private static final String INTEGER = "integer";
 
-        /** String Attribute containing sensitive data **/
+        /**
+         * String Attribute containing sensitive data
+         **/
         private static final String SECRET = "secret";
 
-        /** Attribute containing file data in Base64 string **/
+        /**
+         * Attribute containing file data in Base64 string
+         **/
         private static final String FILE = "file";
 
-        /** Boolean Attribute taking on values {@code true} or {@code false} **/
+        /**
+         * Boolean Attribute taking on values {@code true} or {@code false}
+         **/
         private static final String BOOLEAN = "boolean";
 
-        /** Special Attribute type representing Credential **/
+        /**
+         * Special Attribute type representing Credential
+         **/
         private static final String CREDENTIAL = "credential";
 
-        /** Attribute type representing date only **/
+        /**
+         * Attribute type representing date only
+         **/
         private static final String DATE = "date";
 
-        /** Attribute type representing float number **/
+        /**
+         * Attribute type representing float number
+         **/
         private static final String FLOAT = "float";
 
-        /** Attribute type representing general data object **/
+        /**
+         * Attribute type representing general data object
+         **/
         private static final String OBJECT = "object";
 
-        /** Attribute type representing text, which is multiline data **/
+        /**
+         * Attribute type representing text, which is multiline data
+         **/
         private static final String TEXT = "text";
 
-        /** Attribute type representing time only **/
+        /**
+         * Attribute type representing time only
+         **/
         private static final String TIME = "time";
 
-        /** Attribute type representing date and time **/
+        /**
+         * Attribute type representing date and time
+         **/
         private static final String DATETIME = "datetime";
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
@@ -44,7 +44,7 @@ public class BaseAttributeContent<T> extends AttributeContent {
     public boolean equals(Object o) {
         if (this == o) return true;
         BaseAttributeContent<?> that = (BaseAttributeContent<?>) o;
-        return Objects.equals(this.reference, that.reference) && Objects.equals(this.data, that.data);
+        return Objects.equals(this.reference, that.reference);
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class BaseAttributeContent<T> extends AttributeContent {
     @Schema(description = "Content Reference")
     private String reference;
@@ -36,5 +38,17 @@ public class BaseAttributeContent<T> extends AttributeContent {
 
     public void setData(T data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        BaseAttributeContent<?> that = (BaseAttributeContent<?>) o;
+        return Objects.equals(this.reference, that.reference) && Objects.equals(this.data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reference, data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BooleanAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BooleanAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class BooleanAttributeContent extends BaseAttributeContent<Boolean> {
 
     @Schema(description = "Boolean attribute value", required = true)
@@ -25,5 +27,19 @@ public class BooleanAttributeContent extends BaseAttributeContent<Boolean> {
 
     public void setData(Boolean data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BooleanAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        BooleanAttributeContent that = (BooleanAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
@@ -27,4 +27,6 @@ public class CredentialAttributeContent extends BaseAttributeContent<CredentialD
     public void setData(CredentialDto data) {
         this.data = data;
     }
+
+
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
+import java.util.Objects;
 
 public class DateAttributeContent extends BaseAttributeContent<LocalDate> {
 
@@ -30,5 +31,19 @@ public class DateAttributeContent extends BaseAttributeContent<LocalDate> {
 
     public void setData(LocalDate data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DateAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        DateAttributeContent that = (DateAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 public class DateTimeAttributeContent extends BaseAttributeContent<ZonedDateTime> {
 
@@ -37,5 +38,19 @@ public class DateTimeAttributeContent extends BaseAttributeContent<ZonedDateTime
     @Override
     public void setData(ZonedDateTime data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DateTimeAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        DateTimeAttributeContent that = (DateTimeAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FileAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FileAttributeContent.java
@@ -4,6 +4,8 @@ import com.czertainly.api.model.common.attribute.v2.content.data.FileAttributeCo
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FileAttributeContent extends BaseAttributeContent<FileAttributeContentData> {
 
@@ -27,5 +29,19 @@ public class FileAttributeContent extends BaseAttributeContent<FileAttributeCont
     @Override
     public void setData(FileAttributeContentData data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FileAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        FileAttributeContent that = (FileAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FloatAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FloatAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class FloatAttributeContent extends BaseAttributeContent<Float> {
 
     @Schema(description = "Float attribute value", required = true)
@@ -26,5 +28,19 @@ public class FloatAttributeContent extends BaseAttributeContent<Float> {
 
     public void setData(Float data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FloatAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        FloatAttributeContent that = (FloatAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/IntegerAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/IntegerAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class IntegerAttributeContent extends BaseAttributeContent<Integer> {
 
     @Schema(description = "Integer attribute value", required = true)
@@ -27,5 +29,19 @@ public class IntegerAttributeContent extends BaseAttributeContent<Integer> {
     @Override
     public void setData(Integer data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IntegerAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        IntegerAttributeContent that = (IntegerAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/ObjectAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/ObjectAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class ObjectAttributeContent extends BaseAttributeContent<Object> {
 
     @Schema(description = "Object attribute content data", required = true)
@@ -25,5 +27,19 @@ public class ObjectAttributeContent extends BaseAttributeContent<Object> {
 
     public void setData(Object data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObjectAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        ObjectAttributeContent that = (ObjectAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/SecretAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/SecretAttributeContent.java
@@ -4,6 +4,8 @@ import com.czertainly.api.model.common.attribute.v2.content.data.SecretAttribute
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SecretAttributeContent extends BaseAttributeContent<SecretAttributeContentData> {
 
@@ -26,5 +28,18 @@ public class SecretAttributeContent extends BaseAttributeContent<SecretAttribute
     @Override
     public void setData(SecretAttributeContentData data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SecretAttributeContent)) return false;
+        SecretAttributeContent that = (SecretAttributeContent) o;
+        return Objects.equals(this.data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/StringAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/StringAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class StringAttributeContent extends BaseAttributeContent<String> {
 
     @Schema(description = "String attribute value", required = true)
@@ -26,5 +28,18 @@ public class StringAttributeContent extends BaseAttributeContent<String> {
 
     public void setData(String data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StringAttributeContent)) return false;
+        StringAttributeContent that = (StringAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TextAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TextAttributeContent.java
@@ -2,6 +2,8 @@ package com.czertainly.api.model.common.attribute.v2.content;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Objects;
+
 public class TextAttributeContent extends BaseAttributeContent<String> {
 
     @Schema(description = "Text attribute value", required = true)
@@ -20,5 +22,19 @@ public class TextAttributeContent extends BaseAttributeContent<String> {
 
     public void setData(String data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TextAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        TextAttributeContent that = (TextAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalTime;
+import java.util.Objects;
 
 public class TimeAttributeContent extends BaseAttributeContent<LocalTime> {
 
@@ -32,5 +33,19 @@ public class TimeAttributeContent extends BaseAttributeContent<LocalTime> {
     @Override
     public void setData(LocalTime data) {
         this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TimeAttributeContent)) return false;
+        if (!super.equals(o)) return false;
+        TimeAttributeContent that = (TimeAttributeContent) o;
+        return Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
     }
 }

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/FileAttributeContentData.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/FileAttributeContentData.java
@@ -5,6 +5,8 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.util.MimeType;
 
+import java.util.Objects;
+
 public class FileAttributeContentData {
 
     @Schema(description = "File content", required = true)
@@ -41,6 +43,19 @@ public class FileAttributeContentData {
 
     public void setMimeType(MimeType mimeType) {
         this.mimeType = mimeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FileAttributeContentData)) return false;
+        FileAttributeContentData that = (FileAttributeContentData) o;
+        return Objects.equals(content, that.content) && Objects.equals(fileName, that.fileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content, fileName);
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/SecretAttributeContentData.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/SecretAttributeContentData.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import java.util.Objects;
+
 public class SecretAttributeContentData {
 
     @Schema(description = "Secret attribute data")
@@ -38,6 +40,19 @@ public class SecretAttributeContentData {
 
     public void setProtectionLevel(ProtectionLevel protectionLevel) {
         this.protectionLevel = protectionLevel;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SecretAttributeContentData)) return false;
+        SecretAttributeContentData that = (SecretAttributeContentData) o;
+        return Objects.equals(this.secret, that.secret);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(secret);
     }
 
     @Override

--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -361,7 +361,7 @@ public class AttributeDefinitionUtils {
                 switch (definition.getContentType()) {
                     case STRING:
                         BaseAttributeContent<?> stringBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, StringAttributeContent.class);
-                        if (stringBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !stringBaseAttributeContent.getData().getClass().isAssignableFrom(AttributeContentType.getClass(definition.getContentType()))) {
+                        if (stringBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -369,7 +369,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case INTEGER:
                         BaseAttributeContent<?> integerBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, IntegerAttributeContent.class);
-                        if (integerBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !integerBaseAttributeContent.getData().getClass().isAssignableFrom(AttributeContentType.getClass(definition.getContentType()))) {
+                        if (integerBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -377,7 +377,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case SECRET:
                         BaseAttributeContent<?> secretBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, SecretAttributeContent.class);
-                        if (secretBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !secretBaseAttributeContent.getData().getClass().isAssignableFrom(SecretAttributeContentData.class)) {
+                        if (secretBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -385,7 +385,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case BOOLEAN:
                         BaseAttributeContent<?> boolBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, BooleanAttributeContent.class);
-                        if (boolBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !boolBaseAttributeContent.getData().getClass().isAssignableFrom(AttributeContentType.getClass(definition.getContentType()))) {
+                        if (boolBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null ) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -393,7 +393,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case FLOAT:
                         BaseAttributeContent<?> floatBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, FloatAttributeContent.class);
-                        if (floatBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !floatBaseAttributeContent.getData().getClass().isAssignableFrom(AttributeContentType.getClass(definition.getContentType()))) {
+                        if (floatBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -401,7 +401,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case TEXT:
                         BaseAttributeContent<?> textBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, TextAttributeContent.class);
-                        if (textBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null || !textBaseAttributeContent.getData().getClass().isAssignableFrom(AttributeContentType.getClass(definition.getContentType()))) {
+                        if (textBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null ) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -743,5 +743,18 @@ public class AttributeDefinitionUtils {
             return listContent;
         }
         return null;
+    }
+
+    public static boolean checkAttributeEquality(List<RequestAttributeDto> requestAttributes, List<DataAttribute> attributes) {
+        for (RequestAttributeDto requestAttribute : requestAttributes) {
+            DataAttribute attribute = getAttributeDefinition(requestAttribute.getName(), attributes);
+            if (attribute == null) {
+                continue;
+            }
+            if (!getAttributeContent(requestAttribute.getName(), requestAttributes, AttributeContentType.getClass(attribute.getContentType())).equals(getAttributeContent(requestAttribute.getName(), attributes, AttributeContentType.getClass(attribute.getContentType())))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -14,7 +14,6 @@ import com.czertainly.api.model.common.attribute.v2.callback.AttributeCallbackMa
 import com.czertainly.api.model.common.attribute.v2.callback.AttributeValueTarget;
 import com.czertainly.api.model.common.attribute.v2.callback.RequestAttributeCallback;
 import com.czertainly.api.model.common.attribute.v2.content.*;
-import com.czertainly.api.model.common.attribute.v2.content.data.SecretAttributeContentData;
 import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -385,7 +384,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case BOOLEAN:
                         BaseAttributeContent<?> boolBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, BooleanAttributeContent.class);
-                        if (boolBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null ) {
+                        if (boolBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -401,7 +400,7 @@ public class AttributeDefinitionUtils {
                         break;
                     case TEXT:
                         BaseAttributeContent<?> textBaseAttributeContent = ATTRIBUTES_OBJECT_MAPPER.convertValue(baseAttributeContent, TextAttributeContent.class);
-                        if (textBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null ) {
+                        if (textBaseAttributeContent.getData() == null || AttributeContentType.getClass(definition.getContentType()) == null) {
                             errors.add(ValidationError.create("Wrong value of Attribute {} {}.", properties.getLabel(), definition.getType()));
                             wrongValue = true;
                             break;
@@ -745,13 +744,17 @@ public class AttributeDefinitionUtils {
         return null;
     }
 
+    /**
+     * Function return true if the attributes are equal. And returns false if the attribute are not equal
+     *
+     * @param requestAttributes List of request attribute DTOs
+     * @param attributes        List of attribute definitions
+     * @return True if attribute is equal and false if attribute is not equal
+     */
     public static boolean checkAttributeEquality(List<RequestAttributeDto> requestAttributes, List<DataAttribute> attributes) {
         for (RequestAttributeDto requestAttribute : requestAttributes) {
             DataAttribute attribute = getAttributeDefinition(requestAttribute.getName(), attributes);
-            if (attribute == null) {
-                continue;
-            }
-            if (!getAttributeContent(requestAttribute.getName(), requestAttributes, AttributeContentType.getClass(attribute.getContentType())).equals(getAttributeContent(requestAttribute.getName(), attributes, AttributeContentType.getClass(attribute.getContentType())))) {
+            if (attribute == null || !getAttributeContent(requestAttribute.getName(), requestAttributes, AttributeContentType.getClass(attribute.getContentType())).equals(getAttributeContent(requestAttribute.getName(), attributes, AttributeContentType.getClass(attribute.getContentType())))) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR contains the following changes:

1. Including equals and HashCode method to all the attribute content type classes
2. Include attribute equality method in the AttributeDefinitionUtils
3. Update the test cases
4. Include getClass method in the AttributeContentType to get the Class Name based on the code
links 3KeyCompany/CZERTAINLY-Core#204