### PR TITLE
Mask Secret for Response Attribute DTOs

### DIFF
--- a/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
+++ b/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
@@ -1,0 +1,84 @@
+package com.czertainly.api.config.serializer;
+
+import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
+import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeContent;
+import com.czertainly.api.model.common.attribute.v2.content.SecretAttributeContent;
+import com.czertainly.api.model.core.credential.CredentialDto;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResponseAttributeSerializer extends StdSerializer<List<BaseAttributeContent>> {
+
+    public ResponseAttributeSerializer() {
+        this(null);
+    }
+
+    public ResponseAttributeSerializer(Class<List<BaseAttributeContent>> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(List<BaseAttributeContent> response, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        ResponseAttributeDto responseAttributeDto = (ResponseAttributeDto) gen.getCurrentValue();
+        if (response == null) {
+            gen.writeNull();
+            return;
+        }
+        if (responseAttributeDto.getContentType() == null) {
+            gen.writeStartArray();
+            for (BaseAttributeContent content : response) {
+                gen.writeObject(content);
+            }
+            gen.writeEndArray();
+            return;
+        }
+        ObjectMapper objectMapper = new ObjectMapper();
+        if (responseAttributeDto.getContentType().equals(AttributeContentType.SECRET)) {
+            gen.writeStartArray();
+            for (BaseAttributeContent content : responseAttributeDto.getContent()) {
+                SecretAttributeContent secretAttributeContent = objectMapper.convertValue(content, SecretAttributeContent.class);
+                secretAttributeContent.setData(null);
+                gen.writeObject(secretAttributeContent);
+            }
+        } else if (responseAttributeDto.getContentType().equals(AttributeContentType.CREDENTIAL)) {
+            gen.writeStartArray();
+            for (BaseAttributeContent credential : responseAttributeDto.getContent()) {
+                CredentialAttributeContent credentialAttributeContent = objectMapper.convertValue(credential, CredentialAttributeContent.class);
+                List<ResponseAttributeDto> credentialAttributes = new ArrayList<>();
+                CredentialDto credentialDto = credentialAttributeContent.getData();
+                for (ResponseAttributeDto credentialAttribute : credentialDto.getAttributes()) {
+                    List<BaseAttributeContent> credentialAttributeContents = new ArrayList<>();
+                    if (credentialAttribute.getContentType().equals(AttributeContentType.SECRET)) {
+                        for (BaseAttributeContent baseAttributeContent : credentialAttribute.getContent()) {
+                            SecretAttributeContent secretAttributeContent = objectMapper.convertValue(baseAttributeContent, SecretAttributeContent.class);
+                            secretAttributeContent.setData(null);
+                            credentialAttributeContents.add(secretAttributeContent);
+                        }
+                    } else {
+                        credentialAttributeContents.addAll(credentialAttribute.getContent());
+                    }
+                    credentialAttribute.setContent(credentialAttributeContents);
+                    credentialAttributes.add(credentialAttribute);
+                }
+                credentialDto.setAttributes(credentialAttributes);
+                credential.setData(credentialDto);
+                gen.writeObject(credential);
+            }
+        } else {
+            gen.writeStartArray();
+            for (BaseAttributeContent content : response) {
+                gen.writeObject(content);
+            }
+        }
+        gen.writeEndArray();
+    }
+}
+

--- a/src/main/java/com/czertainly/api/model/client/attribute/ResponseAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/ResponseAttributeDto.java
@@ -1,8 +1,10 @@
 package com.czertainly.api.model.client.attribute;
 
+import com.czertainly.api.config.serializer.ResponseAttributeSerializer;
 import com.czertainly.api.model.common.attribute.v2.AttributeType;
 import com.czertainly.api.model.common.attribute.v2.content.*;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -71,23 +73,24 @@ public class ResponseAttributeDto {
      * Content of the Attribute
      **/
     @Schema(
-        description = "Content of the Attribute",
-        type = "object",
-        oneOf = {
-            BooleanAttributeContent.class,
-            CredentialAttributeContent.class,
-            DateAttributeContent.class,
-            DateTimeAttributeContent.class,
-            FileAttributeContent.class,
-            FloatAttributeContent.class,
-            IntegerAttributeContent.class,
-            ObjectAttributeContent.class,
-            SecretAttributeContent.class,
-            StringAttributeContent.class,
-            TextAttributeContent.class,
-            TimeAttributeContent.class
-        }
+            description = "Content of the Attribute",
+            type = "object",
+            oneOf = {
+                    BooleanAttributeContent.class,
+                    CredentialAttributeContent.class,
+                    DateAttributeContent.class,
+                    DateTimeAttributeContent.class,
+                    FileAttributeContent.class,
+                    FloatAttributeContent.class,
+                    IntegerAttributeContent.class,
+                    ObjectAttributeContent.class,
+                    SecretAttributeContent.class,
+                    StringAttributeContent.class,
+                    TextAttributeContent.class,
+                    TimeAttributeContent.class
+            }
     )
+    @JsonSerialize(using = ResponseAttributeSerializer.class)
     private List<BaseAttributeContent> content;
 
     public ResponseAttributeDto() {

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataCreateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataCreateRequestDto.java
@@ -1,12 +1,9 @@
 package com.czertainly.api.model.client.attribute.metadata;
 
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
-import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import java.util.List;
 
 public class GlobalMetadataCreateRequestDto {
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataDefinitionDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataDefinitionDetailDto.java
@@ -2,12 +2,9 @@ package com.czertainly.api.model.client.attribute.metadata;
 
 import com.czertainly.api.model.client.attribute.AttributeDefinitionDto;
 import com.czertainly.api.model.common.attribute.v2.AttributeType;
-import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import java.util.List;
 
 public class GlobalMetadataDefinitionDetailDto extends AttributeDefinitionDto {
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataUpdateRequestDto.java
@@ -1,11 +1,8 @@
 package com.czertainly.api.model.client.attribute.metadata;
 
-import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import java.util.List;
 
 public class GlobalMetadataUpdateRequestDto {
 

--- a/src/main/java/com/czertainly/api/model/client/metadata/ResponseMetadataDto.java
+++ b/src/main/java/com/czertainly/api/model/client/metadata/ResponseMetadataDto.java
@@ -2,7 +2,6 @@ package com.czertainly.api.model.client.metadata;
 
 import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
 import com.czertainly.api.model.common.NameAndUuidDto;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/CustomAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/CustomAttribute.java
@@ -1,13 +1,7 @@
 package com.czertainly.api.model.common.attribute.v2;
 
-import com.czertainly.api.model.common.attribute.v2.callback.AttributeCallback;
-import com.czertainly.api.model.common.attribute.v2.constraint.BaseAttributeConstraint;
-import com.czertainly.api.model.common.attribute.v2.constraint.DateTimeAttributeConstraint;
-import com.czertainly.api.model.common.attribute.v2.constraint.RangeAttributeConstraint;
-import com.czertainly.api.model.common.attribute.v2.constraint.RegexpAttributeConstraint;
 import com.czertainly.api.model.common.attribute.v2.content.*;
 import com.czertainly.api.model.common.attribute.v2.properties.CustomAttributeProperties;
-import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.apache.commons.lang3.builder.ToStringBuilder;


### PR DESCRIPTION
This PR contains the changes for the following 
1. When the response is sent to the client through  ResponseAttributeDTO, the data of the attribute content type SECRET will be replaced by null
2. Import optimization 

closes #125 