### PR TITLE
Correct Audit Logs endpoints query params schema annotations

### DIFF
--- a/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
@@ -5,6 +5,7 @@ import com.czertainly.api.model.common.ErrorMessageDto;
 import com.czertainly.api.model.core.audit.AuditLogFilter;
 import com.czertainly.api.model.core.audit.AuditLogResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,10 +15,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -57,18 +55,18 @@ public interface AuditLogController {
 	@Operation(summary = "List Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit logs")})
 	@RequestMapping(method = RequestMethod.GET, produces = {"application/json"})
-    public AuditLogResponseDto listAuditLogs(AuditLogFilter filter, Pageable pageable);
+    public AuditLogResponseDto listAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
 	
 	@Operation(summary = "Export Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Export of audit logs")})
 	@RequestMapping(path = "/export" ,method = RequestMethod.GET, produces = {"application/json"})
-    public ResponseEntity<Resource> exportAuditLogs(AuditLogFilter filter, Pageable pageable);
+    public ResponseEntity<Resource> exportAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
 
 	@Operation(summary = "Purge Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Audit logs purged")})
 	@RequestMapping(path = "/purge" ,method = RequestMethod.GET, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void purgeAuditLogs(AuditLogFilter filter, Pageable pageable);
+	public void purgeAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
 	
 	@Operation(summary = "List Audit Objects")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit Objects") })

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
@@ -15,7 +15,7 @@ public class DateAttributeContent extends BaseAttributeContent<LocalDate> {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonDeserialize(using = LocalDateDeserializer.class)
     @JsonSerialize(using = LocalDateSerializer.class)
-    @Schema(description = "Date attribute value", required = true)
+    @Schema(description = "Date attribute value in format yyyy-MM-dd", required = true)
     private LocalDate data;
 
     public DateAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
@@ -15,7 +15,7 @@ public class DateTimeAttributeContent extends BaseAttributeContent<ZonedDateTime
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     @JsonDeserialize(using = ZonedDateTimeDeserializer.class)
     @JsonSerialize(using = ZonedDateTimeSerializer.class)
-    @Schema(description = "DateTime attribute value", required = true)
+    @Schema(description = "DateTime attribute value in format yyyy-MM-ddTHH:mm:ss.SSSXXX", required = true)
     private ZonedDateTime data;
 
     public DateTimeAttributeContent(ZonedDateTime data) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
@@ -15,7 +15,7 @@ public class TimeAttributeContent extends BaseAttributeContent<LocalTime> {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JsonSerialize(using = LocalTimeSerializer.class)
-    @Schema(description = "Time attribute value", required = true)
+    @Schema(description = "Time attribute value in format HH:mm:ss", required = true, implementation = String.class)
     private LocalTime data;
 
     public TimeAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/core/audit/AuditLogFilter.java
+++ b/src/main/java/com/czertainly/api/model/core/audit/AuditLogFilter.java
@@ -8,52 +8,28 @@ import java.time.LocalDate;
 
 public class AuditLogFilter {
 	
-	@Schema(
-            description = "Author of the action triggered audit log",
-            required = true
-    )
+	@Schema(description = "Author of the action triggered audit log")
     private String author;
 	
-	@Schema(
-            description = "Start time of the filter",
-            required = true
-    )
+	@Schema(description = "Start time of the filter")
     private LocalDate createdFrom;
 	
-	@Schema(
-            description = "End time of the filter",
-            required = true
-    )
+	@Schema(description = "End time of the filter")
     private LocalDate createdTo;
 	
-	@Schema(
-            description = "Status of the filter",
-            required = true
-    )
+	@Schema(description = "Status of the filter")
     private OperationStatusEnum operationStatus;
 	
-	@Schema(
-            description = "Module triggered the action",
-            required = true
-    )
+	@Schema(description = "Module triggered the action")
     private ObjectType origination;
 	
-	@Schema(
-            description = "Module affected by the action",
-            required = true
-    )
+	@Schema(description = "Module affected by the action")
     private ObjectType affected;
 	
-	@Schema(
-            description = "Identifier of the object created",
-            required = true
-    )
+	@Schema(description = "Identifier of the object created")
     private String objectIdentifier;
 	
-	@Schema(
-            description = "Type of the operation",
-            required = true
-    )
+	@Schema(description = "Type of the operation")
     private OperationType operation;
 
     public String getAuthor() {

--- a/src/main/java/com/czertainly/api/model/core/search/SearchCondition.java
+++ b/src/main/java/com/czertainly/api/model/core/search/SearchCondition.java
@@ -1,7 +1,10 @@
 package com.czertainly.api.model.core.search;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.Arrays;
 
+@Schema(enumAsRef = true)
 public enum SearchCondition {
     EQUALS("="),
     NOT_EQUALS("<>"),

--- a/src/main/java/com/czertainly/api/model/core/search/SearchableFields.java
+++ b/src/main/java/com/czertainly/api/model/core/search/SearchableFields.java
@@ -2,12 +2,14 @@ package com.czertainly.api.model.core.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Schema(enumAsRef = true)
 public enum SearchableFields {
     COMMON_NAME("commonName"),
     SERIAL_NUMBER("serialNumber"),


### PR DESCRIPTION
- correct Audit Logs endpoints query params schema annotations to be nullable together with filter properties
- mark certificate search fields and operations as enum schema
- add description to date/time attribute contents