### PR TITLE
Update Credential Attribute Content with New Content Data Type

### DIFF
--- a/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
+++ b/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
@@ -1,11 +1,12 @@
 package com.czertainly.api.config.serializer;
 
 import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
+import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.AttributeContentType;
 import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.SecretAttributeContent;
-import com.czertainly.api.model.core.credential.CredentialDto;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -52,9 +53,9 @@ public class ResponseAttributeSerializer extends StdSerializer<List<BaseAttribut
             gen.writeStartArray();
             for (BaseAttributeContent credential : responseAttributeDto.getContent()) {
                 CredentialAttributeContent credentialAttributeContent = objectMapper.convertValue(credential, CredentialAttributeContent.class);
-                List<ResponseAttributeDto> credentialAttributes = new ArrayList<>();
-                CredentialDto credentialDto = credentialAttributeContent.getData();
-                for (ResponseAttributeDto credentialAttribute : credentialDto.getAttributes()) {
+                List<DataAttribute> credentialAttributes = new ArrayList<>();
+                CredentialAttributeContentData credentialDto = credentialAttributeContent.getData();
+                for (DataAttribute credentialAttribute : credentialDto.getAttributes()) {
                     List<BaseAttributeContent> credentialAttributeContents = new ArrayList<>();
                     if (credentialAttribute.getContentType().equals(AttributeContentType.SECRET)) {
                         for (BaseAttributeContent baseAttributeContent : credentialAttribute.getContent()) {

--- a/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
@@ -52,12 +52,12 @@ import java.util.Optional;
 				)
 		})
 public interface AuditLogController {
-	
+
 	@Operation(summary = "List Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit logs")})
 	@RequestMapping(method = RequestMethod.GET, produces = {"application/json"})
-    public AuditLogResponseDto listAuditLogs(Optional<AuditLogFilter> filter, Optional<Pageable> pageable);
-	
+    public AuditLogResponseDto listAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
+
 	@Operation(summary = "Export Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Export of audit logs")})
 	@RequestMapping(path = "/export" ,method = RequestMethod.GET, produces = {"application/json"})
@@ -68,17 +68,17 @@ public interface AuditLogController {
 	@RequestMapping(path = "/purge" ,method = RequestMethod.GET, produces = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void purgeAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
-	
+
 	@Operation(summary = "List Audit Objects")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit Objects") })
 	@RequestMapping(path = "/objects" ,method = RequestMethod.GET, produces = {"application/json"})
     public List<String> listObjects();
-	
+
 	@Operation(summary = "List Audit Operations")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit operations")})
 	@RequestMapping(path = "/operations" ,method = RequestMethod.GET, produces = {"application/json"})
     public List<String> listOperations();
-	
+
 	@Operation(summary = "List Status")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit log status")})
 	@RequestMapping(path = "/statuses" ,method = RequestMethod.GET, produces = {"application/json"})

--- a/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/AuditLogController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/v1/auditLogs")
@@ -55,7 +56,7 @@ public interface AuditLogController {
 	@Operation(summary = "List Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "List of audit logs")})
 	@RequestMapping(method = RequestMethod.GET, produces = {"application/json"})
-    public AuditLogResponseDto listAuditLogs(@RequestParam(required = false) AuditLogFilter filter, @RequestParam(required = false) Pageable pageable);
+    public AuditLogResponseDto listAuditLogs(Optional<AuditLogFilter> filter, Optional<Pageable> pageable);
 	
 	@Operation(summary = "Export Audit logs")
 	@ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Export of audit logs")})

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
@@ -1,30 +1,31 @@
 package com.czertainly.api.model.common.attribute.v2.content;
 
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public class CredentialAttributeContent extends BaseAttributeContent<CredentialDto> {
+public class CredentialAttributeContent extends BaseAttributeContent<CredentialAttributeContentData> {
 
     @Schema(description = "Credential attribute content data", required = true)
-    private CredentialDto data;
+    private CredentialAttributeContentData data;
 
     public CredentialAttributeContent() {
     }
 
-    public CredentialAttributeContent(CredentialDto data) {
+    public CredentialAttributeContent(CredentialAttributeContentData data) {
         this.data = data;
     }
 
-    public CredentialAttributeContent(String reference, CredentialDto data) {
+    public CredentialAttributeContent(String reference, CredentialAttributeContentData data) {
         super(reference);
         this.data = data;
     }
 
-    public CredentialDto getData() {
+    public CredentialAttributeContentData getData() {
         return data;
     }
 
-    public void setData(CredentialDto data) {
+    public void setData(CredentialAttributeContentData data) {
         this.data = data;
     }
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/CredentialAttributeContentData.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/CredentialAttributeContentData.java
@@ -1,0 +1,47 @@
+package com.czertainly.api.model.common.attribute.v2.content.data;
+
+import com.czertainly.api.model.common.NameAndUuidDto;
+import com.czertainly.api.model.common.attribute.v2.DataAttribute;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import java.util.List;
+
+public class CredentialAttributeContentData extends NameAndUuidDto {
+
+    @Schema(description = "Credential Kind",
+            example = "SoftKeyStore, Basic, ApiKey, etc",
+            required = true)
+    private String kind;
+
+    @Schema(description = "List of Credential Attributes",
+            required = true)
+    private List<DataAttribute> attributes;
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public List<DataAttribute> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<DataAttribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("uuid", uuid)
+                .append("name", name)
+                .append("kind", kind)
+                .append("attributes", attributes)
+                .toString();
+    }
+}

--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -14,6 +14,7 @@ import com.czertainly.api.model.common.attribute.v2.callback.AttributeCallbackMa
 import com.czertainly.api.model.common.attribute.v2.callback.AttributeValueTarget;
 import com.czertainly.api.model.common.attribute.v2.callback.RequestAttributeCallback;
 import com.czertainly.api.model.common.attribute.v2.content.*;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -41,7 +42,7 @@ public class AttributeDefinitionUtils {
         return definition != null;
     }
 
-    public static <T extends Object> T getRequestAttributes(String name, List<?> attributes) {
+        public static <T extends Object> T getRequestAttributes(String name, List<?> attributes) {
         if (attributes.size() == 0) {
             return null;
         }
@@ -141,7 +142,7 @@ public class AttributeDefinitionUtils {
         return converted;
     }
 
-    public static CredentialDto getCredentialContent(String name, List<RequestAttributeDto> attributes) {
+    public static CredentialAttributeContentData getCredentialContent(String name, List<RequestAttributeDto> attributes) {
         List<CredentialAttributeContent> content = AttributeDefinitionUtils.getAttributeContent(name, attributes, CredentialAttributeContent.class);
         if (content != null && !content.isEmpty()) {
             return content.get(0).getData();

--- a/src/test/java/com/czertainly/util/AttributeDefinitionUtilsTest.java
+++ b/src/test/java/com/czertainly/util/AttributeDefinitionUtilsTest.java
@@ -13,6 +13,7 @@ import com.czertainly.api.model.common.attribute.v2.callback.AttributeValueTarge
 import com.czertainly.api.model.common.attribute.v2.callback.RequestAttributeCallback;
 import com.czertainly.api.model.common.attribute.v2.constraint.AttributeConstraintType;
 import com.czertainly.api.model.common.attribute.v2.content.*;
+import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.czertainly.core.util.AttributeDefinitionUtils;
@@ -98,10 +99,10 @@ public class AttributeDefinitionUtilsTest {
         String attribute1Name = "testAttribute1";
         List<RequestAttributeDto> credentialAttributes = createAttributes("credAttr", List.of(new IntegerAttributeContent(987)));
 
-        CredentialDto credentialDto = new CredentialDto();
+        CredentialAttributeContentData credentialDto = new CredentialAttributeContentData();
         credentialDto.setUuid(UUID.randomUUID().toString());
         credentialDto.setName("testName");
-        credentialDto.setAttributes(AttributeDefinitionUtils.getResponseAttributes(credentialAttributes));
+        credentialDto.setAttributes(AttributeDefinitionUtils.clientAttributeConverter(credentialAttributes));
 
         RequestAttributeDto attribute1 = new RequestAttributeDto();
         attribute1.setName(attribute1Name);
@@ -109,7 +110,7 @@ public class AttributeDefinitionUtilsTest {
 
         List<RequestAttributeDto> attributes = List.of(attribute1);
 
-        CredentialDto dto = getCredentialContent(attribute1Name, attributes);
+        CredentialAttributeContentData dto = getCredentialContent(attribute1Name, attributes);
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(credentialDto.getUuid(), dto.getUuid());
         Assertions.assertEquals(credentialDto.getName(), dto.getName());
@@ -290,7 +291,7 @@ public class AttributeDefinitionUtilsTest {
         RequestAttributeDto attribute = new RequestAttributeDto();
         attribute.setName(attributeName);
 
-        CredentialDto credential = new CredentialDto();
+        CredentialAttributeContentData credential = new CredentialAttributeContentData();
         credential.setName("testName");
         credential.setUuid("testUuid");
 
@@ -310,7 +311,7 @@ public class AttributeDefinitionUtilsTest {
         definition.setType(AttributeType.DATA);
         definition.setContentType(AttributeContentType.CREDENTIAL);
 
-        CredentialAttributeContent credentialContent = new CredentialAttributeContent(attributeName, new CredentialDto());
+        CredentialAttributeContent credentialContent = new CredentialAttributeContent(attributeName, new CredentialAttributeContentData());
 
         RequestAttributeDto attribute = new RequestAttributeDto();
         attribute.setName(attributeName);


### PR DESCRIPTION
For the credential Attribute type, create a new data type for the content as the credential contains ResponseAttributeDto and will not propagate the secrets to the connector

closes #133 