### PR TITLE
Set Deserialization on Unknown Properties as false

### DIFF
--- a/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
+++ b/src/main/java/com/czertainly/api/config/serializer/ResponseAttributeSerializer.java
@@ -8,6 +8,7 @@ import com.czertainly.api.model.common.attribute.v2.content.CredentialAttributeC
 import com.czertainly.api.model.common.attribute.v2.content.SecretAttributeContent;
 import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -41,7 +42,8 @@ public class ResponseAttributeSerializer extends StdSerializer<List<BaseAttribut
             gen.writeEndArray();
             return;
         }
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         if (responseAttributeDto.getContentType().equals(AttributeContentType.SECRET)) {
             gen.writeStartArray();
             for (BaseAttributeContent content : responseAttributeDto.getContent()) {


### PR DESCRIPTION
When the object mapper ties to deserialize the content in the response attributes, it is failing if there are unknown properties in the database which is not a desired behavior. Even if there are unknown properties it should ignore them. These unknown properties are because of the multiple changes in the DB added at the time of development. This will not occur with the release branch