### PR TITLE
Upgrade swagger annotations library to new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>2.2.4</version>
+            <version>2.2.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/czertainly/api/model/client/acme/AcmeAccountListResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/acme/AcmeAccountListResponseDto.java
@@ -12,50 +12,50 @@ public class AcmeAccountListResponseDto {
 
     @Schema(
             description = "ID of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "HJAT6gc7i6"
     )
     private String accountId;
     @Schema(
             description = "UUID of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "6b55de1c-844f-11ec-a8a3-0242ac120002"
     )
     private String uuid;
     @Schema(
             description = "Enabled flag. true = enabled, false=disabled",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "false"
     )
     private Boolean enabled;
     @Schema(
             description = "Total number of Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "4"
     )
     private Integer totalOrders;
     @Schema(
             description = "Status of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "VALID"
     )
     private AccountStatus status;
     @Schema(
             description = "Name of the RA Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "RAProfile1"
     )
     private String raProfileName;
     @Schema(
             description = "Name of the ACME Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "ACMEProfile1"
     )
     private String acmeProfileName;
 
     @Schema(
             description = "UUID of the ACME Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "6b55de1c-844f-11ec-a8a3-0242ac120002"
     )
     private String acmeProfileUuid;

--- a/src/main/java/com/czertainly/api/model/client/acme/AcmeAccountResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/acme/AcmeAccountResponseDto.java
@@ -12,97 +12,97 @@ public class AcmeAccountResponseDto {
 
     @Schema(
             description = "ID of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "TtrgfYTR6F"
     )
     private String accountId;
     @Schema(
             description = "UUID of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "6b55de1c-844f-11ec-a8a3-0242ac120002"
     )
     private String uuid;
     @Schema(
             description = "Enabled flag. enabled=true, disabled=false",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "false"
     )
     private Boolean enabled;
     @Schema(
             description = "Order count for the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "23"
     )
     private Integer totalOrders;
     @Schema(
             description = "Number of successful Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "2"
     )
     private Integer successfulOrders;
     @Schema(
             description = "Number of failed Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "239"
     )
     private Integer failedOrders;
     @Schema(
             description = "Number of pending Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "24"
     )
     private Integer pendingOrders;
     @Schema(
             description = "Number of valid Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "23"
     )
     private Integer validOrders;
     @Schema(
             description = "Number of processing Orders",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "27"
     )
     private Integer processingOrders;
     @Schema(
             description = "Status of the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "VALID"
     )
     private AccountStatus status;
     @Schema(
             description = "Contact information",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "mailto: someadmin@domain.com"
     )
     private List<String> contact;
     @Schema(
             description = "Terms of Service Agreed",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "true"
     )
     private Boolean termsOfServiceAgreed;
     @Schema(
             description = "Name of the RA Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "RA Profile 1"
     )
     private String raProfileName;
     @Schema(
             description = "UUID of the RA Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "6b55de1c-844f-11ec-a8a3-0242ac120002"
     )
     private String raProfileUuid;
     @Schema(
             description = "Name of the ACME Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "ACME Profile 1"
     )
     private String acmeProfileName;
     @Schema(
             description = "UUID of the ACME Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "6b55de1c-844f-11ec-a8a3-0242ac120002"
     )
     private String acmeProfileUuid;

--- a/src/main/java/com/czertainly/api/model/client/acme/AcmeProfileEditRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/acme/AcmeProfileEditRequestDto.java
@@ -67,12 +67,12 @@ public class AcmeProfileEditRequestDto {
     private Integer validity;
     @Schema(
             description = "List of Attributes to issue Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> issueCertificateAttributes;
     @Schema(
             description = "List of Attributes to revoke Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> revokeCertificateAttributes;
     @Schema(

--- a/src/main/java/com/czertainly/api/model/client/acme/AcmeProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/acme/AcmeProfileRequestDto.java
@@ -11,7 +11,7 @@ public class AcmeProfileRequestDto {
 
     @Schema(
             description = "Name of the ACME Profile",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "Profile Name 1"
     )
     private String name;
@@ -62,12 +62,12 @@ public class AcmeProfileRequestDto {
     private Integer validity;
     @Schema(
             description = "List of Attributes to issue Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> issueCertificateAttributes;
     @Schema(
             description = "List of Attributes to revoke Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> revokeCertificateAttributes;
     @Schema(

--- a/src/main/java/com/czertainly/api/model/client/attribute/AttributeDefinitionDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/AttributeDefinitionDto.java
@@ -10,25 +10,25 @@ public class AttributeDefinitionDto {
     /**
      * Name of the Attribute
      */
-    @Schema(description = "UUID of the Attribute", required = true)
+    @Schema(description = "UUID of the Attribute", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
     /**
      * Name of the Attribute
      */
-    @Schema(description = "Name of the Attribute", required = true)
+    @Schema(description = "Name of the Attribute", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     /**
      * Content Type of the Attribute
      */
-    @Schema(description = "Attribute Content Type", required = true)
+    @Schema(description = "Attribute Content Type", requiredMode = Schema.RequiredMode.REQUIRED)
     private AttributeContentType contentType;
 
     /**
      * Description of the Attribute
      */
-    @Schema(description = "Attribute description", required = true)
+    @Schema(description = "Attribute description", requiredMode = Schema.RequiredMode.REQUIRED)
     private String description;
 
     /**

--- a/src/main/java/com/czertainly/api/model/client/attribute/BaseAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/BaseAttributeDto.java
@@ -37,7 +37,7 @@ public class BaseAttributeDto {
         @Schema(
                 description = "UUID of the Attribute for unique identification",
                 example = "166b5cf52-63f2-11ec-90d6-0242ac120003",
-                required = true
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String uuid;
 
@@ -47,7 +47,7 @@ public class BaseAttributeDto {
         @Schema(
                 description = "Name of the Attribute that is used for identification",
                 example = "Attribute",
-                required = true
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String name;
 
@@ -64,7 +64,7 @@ public class BaseAttributeDto {
          */
         @Schema(
                 description = "Type of the Attribute",
-                required = true,
+                requiredMode = Schema.RequiredMode.REQUIRED,
                 defaultValue = "data"
         )
         private AttributeType type = AttributeType.DATA;

--- a/src/main/java/com/czertainly/api/model/client/attribute/RequestAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/RequestAttributeDto.java
@@ -31,7 +31,7 @@ public class RequestAttributeDto {
     @Schema(
             description = "Name of the Attribute",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -40,7 +40,7 @@ public class RequestAttributeDto {
      **/
     @Schema(
         description = "Content of the Attribute",
-        required = true,
+        requiredMode = Schema.RequiredMode.REQUIRED,
         type = "object",
         oneOf = {
             BooleanAttributeContent.class,

--- a/src/main/java/com/czertainly/api/model/client/attribute/ResponseAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/ResponseAttributeDto.java
@@ -36,7 +36,7 @@ public class ResponseAttributeDto {
     @Schema(
             description = "Name of the Attribute",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -46,7 +46,7 @@ public class ResponseAttributeDto {
     @Schema(
             description = "Label of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 
@@ -55,7 +55,7 @@ public class ResponseAttributeDto {
      **/
     @Schema(
             description = "Type of the Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeType type;
 
@@ -65,7 +65,7 @@ public class ResponseAttributeDto {
     @Schema(
             description = "Content Type of the Attribute",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeContentType contentType;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeCreateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeCreateRequestDto.java
@@ -24,19 +24,19 @@ public class CustomAttributeCreateRequestDto {
     /**
      * Name of the Attribute
      */
-    @Schema(description = "Name of the Attribute", required = true)
+    @Schema(description = "Name of the Attribute", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     /**
      * Content Type of the Attribute
      */
-    @Schema(description = "Attribute Content Type", required = true)
+    @Schema(description = "Attribute Content Type", requiredMode = Schema.RequiredMode.REQUIRED)
     private AttributeContentType contentType;
 
     /**
      * Description of the Attribute
      */
-    @Schema(description = "Attribute description", required = true)
+    @Schema(description = "Attribute description", requiredMode = Schema.RequiredMode.REQUIRED)
     private String description;
 
     /**
@@ -45,7 +45,7 @@ public class CustomAttributeCreateRequestDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeDefinitionDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeDefinitionDetailDto.java
@@ -16,7 +16,7 @@ public class CustomAttributeDefinitionDetailDto extends AttributeDefinitionDto {
      * Type of the Attribute. For the custom attribute, the type will always be "custom"
      */
     @Schema(description = "Type of the Attribute",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "custom",
             defaultValue = "custom")
     private AttributeType type;
@@ -27,7 +27,7 @@ public class CustomAttributeDefinitionDetailDto extends AttributeDefinitionDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 
@@ -36,7 +36,7 @@ public class CustomAttributeDefinitionDetailDto extends AttributeDefinitionDto {
      **/
     @Schema(
             description = "Boolean determining if the Attribute is required. If true, the Attribute must be provided.",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean required;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/custom/CustomAttributeUpdateRequestDto.java
@@ -23,7 +23,7 @@ public class CustomAttributeUpdateRequestDto {
     /**
      * Description of the Attribute
      */
-    @Schema(description = "Attribute description", required = true)
+    @Schema(description = "Attribute description", requiredMode = Schema.RequiredMode.REQUIRED)
     private String description;
 
     /**
@@ -32,7 +32,7 @@ public class CustomAttributeUpdateRequestDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/ConnectorMetadataPromotionRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/ConnectorMetadataPromotionRequestDto.java
@@ -6,10 +6,10 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ConnectorMetadataPromotionRequestDto {
 
-    @Schema(description = "Metadata UUID", required = true)
+    @Schema(description = "Metadata UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "Connector UUID", required = true)
+    @Schema(description = "Connector UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/ConnectorMetadataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/ConnectorMetadataResponseDto.java
@@ -6,19 +6,19 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ConnectorMetadataResponseDto {
-    @Schema(description = "Metadata Name", required = true)
+    @Schema(description = "Metadata Name", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "Metadata UUID", required = true)
+    @Schema(description = "Metadata UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "Content Type of the Metadata", required = true)
+    @Schema(description = "Content Type of the Metadata", requiredMode = Schema.RequiredMode.REQUIRED)
     private AttributeContentType contentType;
 
-    @Schema(description = "Metadata Label", required = true)
+    @Schema(description = "Metadata Label", requiredMode = Schema.RequiredMode.REQUIRED)
     private String label;
 
-    @Schema(description = "Connector UUID", required = true)
+    @Schema(description = "Connector UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataCreateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataCreateRequestDto.java
@@ -10,19 +10,19 @@ public class GlobalMetadataCreateRequestDto {
     /**
      * Name of the Attribute
      */
-    @Schema(description = "Name of the Attribute", required = true)
+    @Schema(description = "Name of the Attribute", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     /**
      * Content Type of the Attribute
      */
-    @Schema(description = "Attribute Content Type", required = true)
+    @Schema(description = "Attribute Content Type", requiredMode = Schema.RequiredMode.REQUIRED)
     private AttributeContentType contentType;
 
     /**
      * Description of the Attribute
      */
-    @Schema(description = "Attribute description", required = true)
+    @Schema(description = "Attribute description", requiredMode = Schema.RequiredMode.REQUIRED)
     private String description;
 
     /**
@@ -31,7 +31,7 @@ public class GlobalMetadataCreateRequestDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataDefinitionDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataDefinitionDetailDto.java
@@ -12,7 +12,7 @@ public class GlobalMetadataDefinitionDetailDto extends AttributeDefinitionDto {
      * Type of the Attribute. For the custom attribute, the type will always be "custom"
      */
     @Schema(description = "Type of the Attribute",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "custom",
             defaultValue = "custom")
     private AttributeType type;
@@ -23,7 +23,7 @@ public class GlobalMetadataDefinitionDetailDto extends AttributeDefinitionDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 

--- a/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/attribute/metadata/GlobalMetadataUpdateRequestDto.java
@@ -9,7 +9,7 @@ public class GlobalMetadataUpdateRequestDto {
     /**
      * Description of the Attribute
      */
-    @Schema(description = "Attribute description", required = true)
+    @Schema(description = "Attribute description", requiredMode = Schema.RequiredMode.REQUIRED)
     private String description;
 
     /**
@@ -18,7 +18,7 @@ public class GlobalMetadataUpdateRequestDto {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 

--- a/src/main/java/com/czertainly/api/model/client/auth/AddUserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/auth/AddUserRequestDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class AddUserRequestDto {
 
-    @Schema(description = "Username of the user", required = true, example = "user1")
+    @Schema(description = "Username of the user", requiredMode = Schema.RequiredMode.REQUIRED, example = "user1")
     private String username;
 
     @Schema(description = "Description of the user")

--- a/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/auth/UpdateUserRequestDto.java
@@ -18,18 +18,18 @@ public class UpdateUserRequestDto {
     @Schema(description = "Last name of the user")
     private String lastName;
 
-    @Schema(description = "Email of the user", required = true)
+    @Schema(description = "Email of the user", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
     @Schema(
             description = "Base64 Content of the admin certificate",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String certificateData;
 
     @Schema(
             description = "UUID of the existing certificate in the Inventory. Mandatory if certificate is not provided",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String certificateUuid;
 

--- a/src/main/java/com/czertainly/api/model/client/authority/AuthorityInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/AuthorityInstanceRequestDto.java
@@ -10,23 +10,23 @@ import java.util.List;
 public class AuthorityInstanceRequestDto {
 
     @Schema(description = "Authority instance name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "List of Authority instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttributeDto> customAttributes;
 
     @Schema(description = "UUID of Authority provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Authority instance Kind",
             example = "LegacyEjbca, ADCS, etc",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/client/authority/AuthorityInstanceUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/AuthorityInstanceUpdateRequestDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class AuthorityInstanceUpdateRequestDto {
 
     @Schema(description = "List of Authority instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientAddEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientAddEndEntityRequestDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientAddEndEntityRequestDto extends ClientBaseEndEntityRequestDto {
 
     @Schema(description = "End Entity name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getUsername() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientBaseEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientBaseEndEntityRequestDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class ClientBaseEndEntityRequestDto {
 
     @Schema(description = "RA profile related to End Entity",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected RaProfileDto raProfile;
 
     @Schema(description = "End Entity email")
@@ -22,14 +22,14 @@ public class ClientBaseEndEntityRequestDto {
     protected List<EndEntityExtendedInfoDto> extensionData;
 
     @Schema(description = "End Entity password",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String password;
 
     @Schema(description = "End Entity Subject alternative name")
     protected String subjectAltName;
 
     @Schema(description = "End Entity subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String subjectDN;
 
     public RaProfileDto getRaProfile() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateRevocationDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateRevocationDto.java
@@ -11,15 +11,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientCertificateRevocationDto {
 
     @Schema(description = "Certificate serial number",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateSN;
 
     @Schema(description = "Issuer domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String issuerDN;
 
     @Schema(description = "Revocation reason",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private RevocationReason reason;
 
     public String getCertificateSN() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateSignRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateSignRequestDto.java
@@ -10,15 +10,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientCertificateSignRequestDto {
 
     @Schema(description = "End Entity password",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String password;
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(description = "End Entity username",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getPassword() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateSignResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientCertificateSignResponseDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientCertificateSignResponseDto {
 
     @Schema(description = "Date of signed certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateData;
 
     public String getCertificateData() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientEditEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientEditEndEntityRequestDto.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientEditEndEntityRequestDto extends ClientBaseEndEntityRequestDto {
 
     @Schema(description = "End Entity Subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected EndEntityStatus status;
 
     public EndEntityStatus getStatus() {

--- a/src/main/java/com/czertainly/api/model/client/authority/ClientEndEntityDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/ClientEndEntityDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class ClientEndEntityDto {
 
     @Schema(description = "End Entity subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String subjectDN;
 
     @Schema(description = "End Entity email")
@@ -28,11 +28,11 @@ public class ClientEndEntityDto {
     private String subjectAltName;
 
     @Schema(description = "End Entity Subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private EndEntityStatus status;
 
     @Schema(description = "End Entity name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getSubjectDN() {

--- a/src/main/java/com/czertainly/api/model/client/authority/RevokeAndDeleteRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/authority/RevokeAndDeleteRequestDto.java
@@ -11,13 +11,13 @@ public class RevokeAndDeleteRequestDto {
 	
 	@Schema(
             description = "Reason for the revocation",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Integer reason;
 	
 	@Schema(
             description = "Name of the user",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String username;
 

--- a/src/main/java/com/czertainly/api/model/client/certificate/BulkOperationResponse.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/BulkOperationResponse.java
@@ -4,13 +4,13 @@ import com.czertainly.api.model.core.certificate.BulkOperationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class BulkOperationResponse {
-    @Schema(description = "Status of the operation", required = true)
+    @Schema(description = "Status of the operation", requiredMode = Schema.RequiredMode.REQUIRED)
     private BulkOperationStatus status;
 
-    @Schema(description = "Number of items failed", required = true)
+    @Schema(description = "Number of items failed", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long failedItem;
 
-    @Schema(description = "Message for the action", required = true)
+    @Schema(description = "Message for the action", requiredMode = Schema.RequiredMode.REQUIRED)
     private String message;
 
 

--- a/src/main/java/com/czertainly/api/model/client/certificate/CertificateResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/CertificateResponseDto.java
@@ -6,19 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public class CertificateResponseDto {
-    @Schema(description = "Certificates", required = true)
+    @Schema(description = "Certificates", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<CertificateDto> certificates;
 
-    @Schema(description = "Number of entries per page", required = true)
+    @Schema(description = "Number of entries per page", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer itemsPerPage;
 
-    @Schema(description = "Page number for the request", required = true)
+    @Schema(description = "Page number for the request", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer pageNumber;
 
-    @Schema(description = "Number of pages available", required = true)
+    @Schema(description = "Number of pages available", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer totalPages;
 
-    @Schema(description = "Number of items available", required = true)
+    @Schema(description = "Number of items available", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long totalItems;
 
     public List<CertificateDto> getCertificates() {

--- a/src/main/java/com/czertainly/api/model/client/certificate/CertificateUpdateGroupDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/CertificateUpdateGroupDto.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class CertificateUpdateGroupDto {
 
     @Schema(description = "Group UUID",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String groupUuid;
 
     public String getGroupUuid() {

--- a/src/main/java/com/czertainly/api/model/client/certificate/IdAndCertificateIdDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/IdAndCertificateIdDto.java
@@ -8,13 +8,13 @@ public class IdAndCertificateIdDto {
 	
 	@Schema(
             description = "UUID of the Object",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private String uuid;
 	
 	@Schema(
             description = "List of UUIDs of the Certificates in Inventory",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private List<String> certificateUuids;
 

--- a/src/main/java/com/czertainly/api/model/client/certificate/MultipleGroupUpdateDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/MultipleGroupUpdateDto.java
@@ -8,7 +8,7 @@ public class MultipleGroupUpdateDto {
 	
 	@Schema(
             description = "UUID of the Group",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private String uuid;
 	

--- a/src/main/java/com/czertainly/api/model/client/certificate/SearchFilterRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/SearchFilterRequestDto.java
@@ -7,10 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
 
 public class SearchFilterRequestDto {
-    @Schema(description = "Field to search", required = true)
+    @Schema(description = "Field to search", requiredMode = Schema.RequiredMode.REQUIRED)
     private SearchableFields field;
 
-    @Schema(description = "Condition for the search", required = true)
+    @Schema(description = "Condition for the search", requiredMode = Schema.RequiredMode.REQUIRED)
     private SearchCondition condition;
 
     @Schema(description = "Value to match")

--- a/src/main/java/com/czertainly/api/model/client/certificate/UploadCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/UploadCertificateRequestDto.java
@@ -11,7 +11,7 @@ public class UploadCertificateRequestDto {
 	
 	@Schema(
             description = "Base64 Content of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private String certificate;
 

--- a/src/main/java/com/czertainly/api/model/client/certificate/owner/CertificateOwnerBulkUpdateDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/owner/CertificateOwnerBulkUpdateDto.java
@@ -9,7 +9,7 @@ public class CertificateOwnerBulkUpdateDto {
 	
 	@Schema(
             description = "Owner of the Certificates",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private String owner;
 	

--- a/src/main/java/com/czertainly/api/model/client/certificate/owner/CertificateOwnerRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/owner/CertificateOwnerRequestDto.java
@@ -6,7 +6,7 @@ public class CertificateOwnerRequestDto {
 	
 	@Schema(
             description = "Owner of the certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
 	private String owner;
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceGroupRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceGroupRequestDto.java
@@ -6,13 +6,13 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ComplianceGroupRequestDto {
 
-    @Schema(description = "UUID of the Compliance Provider", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String connectorUuid;
 
-    @Schema(description = "Kind of the Compliance Provider", required = true, example = "default")
+    @Schema(description = "Kind of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "default")
     private String kind;
 
-    @Schema(description = "UUID of the group", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the group", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String groupUuid;
 
     public String getConnectorUuid() {

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceGroupsListResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceGroupsListResponseDto.java
@@ -9,21 +9,21 @@ import java.util.List;
 
 public class ComplianceGroupsListResponseDto {
     @Schema(description = "Name of the Compliance Provider",
-            example = "Provider1", required = true)
+            example = "Provider1", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     @Schema(description = "UUID of the Compliance Provider",
             example = "c35bc88c-d0ef-11ec-9d64-0242ac120003",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Kind of the Compliance Provider",
             example = "Kind1",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "Groups from Compliance Provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ComplianceGroupsResponseDto> groups;
 
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRequestDto.java
@@ -8,7 +8,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import java.util.List;
 
 public class ComplianceProfileRequestDto {
-    @Schema(description = "Name of the Compliance Profile", required = true, example = "Profile 1")
+    @Schema(description = "Name of the Compliance Profile", requiredMode = Schema.RequiredMode.REQUIRED, example = "Profile 1")
     private String name;
 
     @Schema(description = "Description of the Compliance Profile", example = "Profile 1")

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRuleDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRuleDto.java
@@ -15,28 +15,28 @@ public class ComplianceProfileRuleDto extends NameAndUuidDto {
     @Schema(description = "Description of the rule", example = "Sample rule description")
     private String description;
 
-    @Schema(description = "Connector Name", required = true)
+    @Schema(description = "Connector Name", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
-    @Schema(description = "Connector UUID", required = true)
+    @Schema(description = "Connector UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
-    @Schema(description = "Connector Kind", required = true)
+    @Schema(description = "Connector Kind", requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "Group UUID")
     private String groupUuid;
 
-    @Schema(description = "Certificate type for the rule", required = true, example = "X509")
+    @Schema(description = "Certificate type for the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "X509")
     private CertificateType certificateType;
 
-    @Schema(description = "List of attributes for the rule", required = true)
+    @Schema(description = "List of attributes for the rule", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
-    @Schema(description = "UUID of the Compliance Profile", required = true)
+    @Schema(description = "UUID of the Compliance Profile", requiredMode = Schema.RequiredMode.REQUIRED)
     private String complianceProfileUuid;
 
-    @Schema(description = "Name of the Compliance Profile", required = true)
+    @Schema(description = "Name of the Compliance Profile", requiredMode = Schema.RequiredMode.REQUIRED)
     private String complianceProfileName;
 
     public String getDescription() {

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesAdditionRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesAdditionRequestDto.java
@@ -7,12 +7,12 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ComplianceProfileRulesAdditionRequestDto {
     @Schema(description = "UUID of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "c35bc88c-d0ef-11ec-9d64-0242ac120005")
     private String connectorUuid;
 
     @Schema(description = "Kind of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "x509")
     private String kind;
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesDeletionRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesDeletionRequestDto.java
@@ -6,17 +6,17 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ComplianceProfileRulesDeletionRequestDto {
     @Schema(description = "UUID of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "c35bc88c-d0ef-11ec-9d64-0242ac120005")
     private String connectorUuid;
 
     @Schema(description = "Kind of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "x509")
     private String kind;
 
     @Schema(description = "UUID of the rule to be deleted",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "18324c94-e95c-11ec-8fea-0242ac120002")
     private String ruleUuid;
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceProfileRulesRequestDto.java
@@ -9,12 +9,12 @@ import java.util.List;
 
 public class ComplianceProfileRulesRequestDto {
     @Schema(description = "UUID of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "c35bc88c-d0ef-11ec-9d64-0242ac120005")
     private String connectorUuid;
 
     @Schema(description = "Kind of the Compliance Provider",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "x509")
     private String kind;
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRuleAdditionRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRuleAdditionRequestDto.java
@@ -9,13 +9,13 @@ import java.util.List;
 
 public class ComplianceRuleAdditionRequestDto {
 
-    @Schema(description = "UUID of the Compliance Provider", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String connectorUuid;
 
-    @Schema(description = "Kind of the Compliance Provider", required = true, example = "default")
+    @Schema(description = "Kind of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "default")
     private String kind;
 
-    @Schema(description = "UUID of the rule", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String ruleUuid;
 
     @Schema(description = "Attributes for the rule")

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRuleDeletionRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRuleDeletionRequestDto.java
@@ -6,13 +6,13 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ComplianceRuleDeletionRequestDto {
 
-    @Schema(description = "UUID of the Compliance Provider", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String connectorUuid;
 
-    @Schema(description = "Kind of the Compliance Provider", required = true, example = "default")
+    @Schema(description = "Kind of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "default")
     private String kind;
 
-    @Schema(description = "UUID of the rule", required = true, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
+    @Schema(description = "UUID of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "1212a-34dddf34-4334f-34ddfvfdg1y3")
     private String ruleUuid;
 
     public String getConnectorUuid() {

--- a/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRulesListResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/ComplianceRulesListResponseDto.java
@@ -9,21 +9,21 @@ import java.util.List;
 
 public class ComplianceRulesListResponseDto {
     @Schema(description = "Name of the Compliance Provider",
-            example = "Provider1", required = true)
+            example = "Provider1", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     @Schema(description = "UUID of the Compliance Provider",
             example = "c35bc88c-d0ef-11ec-9d64-0242ac120003",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Kind of the Compliance Provider",
             example = "Kind1",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "Rules from Compliance Provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ComplianceRulesResponseDto> rules;
 
 

--- a/src/main/java/com/czertainly/api/model/client/compliance/RaProfileAssociationRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/compliance/RaProfileAssociationRequestDto.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class RaProfileAssociationRequestDto {
     @Schema(description = "List of UUIDs of RA Profiles to be associated",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "[\"18324af0-e95c-11ec-8fea-0242ac120002\",\"18324c94-e95c-11ec-8fea-0242ac120002\"]")
     private List<String> raProfileUuids;
 

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectDto.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ConnectDto {
 
     @Schema(description = "Function Group information of a connector",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private FunctionGroupDto functionGroup;
 
     public FunctionGroupDto getFunctionGroup() {

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectRequestDto.java
@@ -10,16 +10,16 @@ public class ConnectRequestDto {
 
     @Schema(description = "URL of the Connector to connect",
             example = "http://network-discovery-provicer:8080",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String url;
     @Schema(description = "UUID of the Connector. Mandatory if connection is needed for the same Connector")
     private String uuid;
     @Schema(description = "Type of authentication for the Connector",
             example = "none",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private AuthType authType;
     @Schema(description = "List of authentication Attributes. Required if the authentication type is not NONE",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<RequestAttributeDto> authAttributes;
 
     public String getUrl() {

--- a/src/main/java/com/czertainly/api/model/client/connector/ConnectorRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/connector/ConnectorRequestDto.java
@@ -12,18 +12,18 @@ public class ConnectorRequestDto {
 
     @Schema(description = "Name of the Connector",
             example = "Connector1",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
     @Schema(description = "URL of the Connector to connect",
             example = "http://network-discovery-provicer:8080",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String url;
     @Schema(description = "Type of authentication for the Connector",
             example = "none",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private AuthType authType;
     @Schema(description = "List of authentication Attributes. Required if the authentication type is not NONE",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<RequestAttributeDto> authAttributes;
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttributeDto> customAttributes;

--- a/src/main/java/com/czertainly/api/model/client/credential/CredentialRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/credential/CredentialRequestDto.java
@@ -11,23 +11,23 @@ import java.util.List;
 public class CredentialRequestDto implements Serializable {
 
     @Schema(description = "Credential name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Credential Kind",
             example = "SoftKeyStore, Basic, ApiKey, etc",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Credential Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttributeDto> customAttributes;
 
     @Schema(description = "UUID of Credential provider Connector",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
 

--- a/src/main/java/com/czertainly/api/model/client/credential/CredentialUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/credential/CredentialUpdateRequestDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class CredentialUpdateRequestDto implements Serializable {
 
     @Schema(description = "List of Credential Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/client/cryptography/key/BulkKeyUsageRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/key/BulkKeyUsageRequestDto.java
@@ -20,13 +20,13 @@ public class BulkKeyUsageRequestDto {
 
     @Schema(
             description = "Usages for the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<KeyUsage> usage;
 
     @Schema(
             description = "Key UUIDs",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<UUID> uuids;
 }

--- a/src/main/java/com/czertainly/api/model/client/cryptography/key/EditKeyRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/key/EditKeyRequestDto.java
@@ -16,19 +16,19 @@ public class EditKeyRequestDto {
 
     @Schema(
             description = "UUID of the token profile",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenProfileUuid;
 
     @Schema(
             description = "Name of the Cryptographic Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
     @Schema(
             description = "Description of the Cryptographic Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String description;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/key/KeyRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/key/KeyRequestDto.java
@@ -19,13 +19,13 @@ public class KeyRequestDto {
 
     @Schema(
             description = "Name of the Cryptographic Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
     @Schema(
             description = "Description of the Cryptographic Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String description;
 
@@ -41,7 +41,7 @@ public class KeyRequestDto {
 
     @Schema(
             description = "List of Attributes to create a Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/key/KeyRequestType.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/key/KeyRequestType.java
@@ -13,7 +13,7 @@ public enum KeyRequestType {
     KEY_PAIR("keyPair");
 
     @Schema(description = "Type of the key to be generated",
-            example = "secret", required = true)
+            example = "secret", requiredMode = Schema.RequiredMode.REQUIRED)
     private final String code;
 
     KeyRequestType(String code) {

--- a/src/main/java/com/czertainly/api/model/client/cryptography/key/UpdateKeyUsageRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/key/UpdateKeyUsageRequestDto.java
@@ -20,7 +20,7 @@ public class UpdateKeyUsageRequestDto {
 
     @Schema(
             description = "Usages for the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<KeyUsage> usage;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/operations/CipherDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/operations/CipherDataRequestDto.java
@@ -21,13 +21,13 @@ public class CipherDataRequestDto {
 
     @Schema(
             description = "List of cipher Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> cipherAttributes;
 
     @Schema(
             description = "Encrypted/decrypted data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<CipherRequestData> cipherData;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/operations/RandomDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/operations/RandomDataRequestDto.java
@@ -21,7 +21,7 @@ public class RandomDataRequestDto {
 
     @Schema(
             description = "Number of random bytes to generate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int length;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/operations/SignDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/operations/SignDataRequestDto.java
@@ -23,7 +23,7 @@ public class SignDataRequestDto {
 
     @Schema(
             description = "List of cipher Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> signatureAttributes;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/operations/VerifyDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/operations/VerifyDataRequestDto.java
@@ -19,7 +19,7 @@ public class VerifyDataRequestDto extends SignDataRequestDto {
 
     @Schema(
             description = "Signatures to verify",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<SignatureRequestData> signatures;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/token/TokenInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/token/TokenInstanceRequestDto.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class TokenInstanceRequestDto {
     @Schema(
             description = "Name of the Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -29,25 +29,25 @@ public class TokenInstanceRequestDto {
 
     @Schema(
             description = "UUID of the Connector",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String connectorUuid;
 
     @Schema(
             description = "Connector Kind",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String kind;
 
     @Schema(
             description = "Custom Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> customAttributes;
 
     @Schema(
             description = "Attributes for Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 }

--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/AddTokenProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/AddTokenProfileRequestDto.java
@@ -24,7 +24,7 @@ public class AddTokenProfileRequestDto {
 
     @Schema(
             description = "Token Profile name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -35,7 +35,7 @@ public class AddTokenProfileRequestDto {
 
     @Schema(
             description = "List of Attributes to create Token Profile",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/BulkTokenProfileKeyUsageRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/BulkTokenProfileKeyUsageRequestDto.java
@@ -19,7 +19,7 @@ public class BulkTokenProfileKeyUsageRequestDto extends TokenProfileKeyUsageRequ
 
     @Schema(
             description = "Token Profile UUIDs",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<UUID> uuids;
 }

--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/EditTokenProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/EditTokenProfileRequestDto.java
@@ -26,7 +26,7 @@ public class EditTokenProfileRequestDto {
 
     @Schema(
             description = "List of Attributes for Token Profile",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/TokenProfileKeyUsageRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/TokenProfileKeyUsageRequestDto.java
@@ -20,7 +20,7 @@ public class TokenProfileKeyUsageRequestDto {
 
     @Schema(
             description = "Usages for the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<KeyUsage> usage;
 }

--- a/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryDto.java
+++ b/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryDto.java
@@ -8,15 +8,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import java.util.List;
 
 public class DiscoveryDto {
-    @Schema(description = "Discovery name", required = true)
+    @Schema(description = "Discovery name", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
-    @Schema(description = "List of Attributes for Discovery", required = true)
+    @Schema(description = "List of Attributes for Discovery", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttributeDto> customAttributes;
-    @Schema(description = "Discovery Provider UUID", required = true)
+    @Schema(description = "Discovery Provider UUID", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
-    @Schema(description = "Discovery Kind", required = true)
+    @Schema(description = "Discovery Kind", requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     public String getConnectorUuid() {

--- a/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryHistoryDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryHistoryDetailDto.java
@@ -18,13 +18,13 @@ public class DiscoveryHistoryDetailDto extends NameAndUuidDto {
     @Schema(
             description = "Discovery Kind",
             example = "IP-HostName",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String kind;
 
     @Schema(
             description = "Status of Discovery",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private DiscoveryStatus status;
 
@@ -51,23 +51,23 @@ public class DiscoveryHistoryDetailDto extends NameAndUuidDto {
     private Integer totalCertificatesDiscovered;
     @Schema(
             description = "UUID of the Discovery Provider",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String connectorUuid;
 
     @Schema(
             description = "Name of the Discovery Provider",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String connectorName;
     @Schema(
             description = "List of Discovered Certificates",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<DiscoveryCertificatesDto> certificate;
     @Schema(
             description = "List of Discovery Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 

--- a/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryHistoryDto.java
+++ b/src/main/java/com/czertainly/api/model/client/discovery/DiscoveryHistoryDto.java
@@ -13,13 +13,13 @@ public class DiscoveryHistoryDto extends NameAndUuidDto {
     @Schema(
             description = "Discovery Kind",
             example = "IP-HostName",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String kind;
 
     @Schema(
             description = "Status of Discovery",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private DiscoveryStatus status;
 
@@ -44,13 +44,13 @@ public class DiscoveryHistoryDto extends NameAndUuidDto {
 
     @Schema(
             description = "UUID of the Discovery Provider",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String connectorUuid;
 
     @Schema(
             description = "Name of the Discovery Provider",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String connectorName;
 

--- a/src/main/java/com/czertainly/api/model/client/entity/EntityInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/entity/EntityInstanceRequestDto.java
@@ -10,23 +10,23 @@ import java.util.List;
 public class EntityInstanceRequestDto {
 
     @Schema(description = "Entity instance name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "List of Entity instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")
     private List<RequestAttributeDto> customAttributes;
 
     @Schema(description = "UUID of Entity Provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Entity instance Kind",
             example = "Keystore, etc.",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/client/entity/EntityInstanceUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/entity/EntityInstanceUpdateRequestDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class EntityInstanceUpdateRequestDto {
 
     @Schema(description = "List of Entity instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/client/location/AddLocationRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/location/AddLocationRequestDto.java
@@ -14,7 +14,7 @@ public class AddLocationRequestDto {
 
     @Schema
             (description = "Location name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
             )
     private String name;
 
@@ -25,7 +25,7 @@ public class AddLocationRequestDto {
 
     @Schema(
             description = "List of Attributes to register Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/location/EditLocationRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/location/EditLocationRequestDto.java
@@ -19,7 +19,7 @@ public class EditLocationRequestDto {
 
     @Schema(
             description = "List of Attributes for Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/location/IssueToLocationRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/location/IssueToLocationRequestDto.java
@@ -14,19 +14,19 @@ public class IssueToLocationRequestDto {
 
     @Schema(
             description = "RA Profile UUID",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String raProfileUuid;
 
     @Schema(
             description = "List of CSR Attributes for Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> csrAttributes;
 
     @Schema(
             description = "List of certificate issue Attributes for RA Profile",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> issueAttributes;
 

--- a/src/main/java/com/czertainly/api/model/client/location/PushToLocationRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/location/PushToLocationRequestDto.java
@@ -14,7 +14,7 @@ public class PushToLocationRequestDto {
 
     @Schema(
             description = "List of push Attributes for Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/client/metadata/MetadataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/metadata/MetadataResponseDto.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 @Schema(description = "Metadata response attributes with their source connector")
 public class MetadataResponseDto {
-    @Schema(description = "UUID of the Connector", required = true)
+    @Schema(description = "UUID of the Connector", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
-    @Schema(description = "Name of the Connector", required = true)
+    @Schema(description = "Name of the Connector", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
-    @Schema(description = "List of Metadata", required = true)
+    @Schema(description = "List of Metadata", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseMetadataDto> items;
 
     public String getConnectorUuid() {

--- a/src/main/java/com/czertainly/api/model/client/raprofile/ActivateAcmeForRaProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/raprofile/ActivateAcmeForRaProfileRequestDto.java
@@ -9,11 +9,11 @@ import java.util.List;
 
 public class ActivateAcmeForRaProfileRequestDto {
     @Schema(description = "List of Attributes to issue Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> issueCertificateAttributes;
 
     @Schema(description = "List of Attributes to revoke Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> revokeCertificateAttributes;
 
     public List<RequestAttributeDto> getIssueCertificateAttributes() {

--- a/src/main/java/com/czertainly/api/model/client/raprofile/AddRaProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/raprofile/AddRaProfileRequestDto.java
@@ -13,14 +13,14 @@ import java.util.List;
 public class AddRaProfileRequestDto {
 
     @Schema(description = "RA Profile name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "RA Profile description")
     private String description;
 
     @Schema(description = "List of Attributes to create RA Profile",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/client/raprofile/EditRaProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/raprofile/EditRaProfileRequestDto.java
@@ -13,7 +13,7 @@ public class EditRaProfileRequestDto {
     private String description;
 
     @Schema(description = "List of Attributes for RA Profile",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/client/raprofile/RaProfileAcmeDetailResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/client/raprofile/RaProfileAcmeDetailResponseDto.java
@@ -9,16 +9,16 @@ import java.util.List;
 public class RaProfileAcmeDetailResponseDto extends NameAndUuidDto {
 
     @Schema(description = "ACME availability flag - true = yes; false = no",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean isAcmeAvailable;
     @Schema(description = "ACME Directory URL",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String directoryUrl;
     @Schema(description = "List of Attributes to issue Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> issueCertificateAttributes;
     @Schema(description = "List of Attributes to revoke Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> revokeCertificateAttributes;
 
     public Boolean getAcmeAvailable() {

--- a/src/main/java/com/czertainly/api/model/client/raprofile/SimplifiedRaProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/client/raprofile/SimplifiedRaProfileDto.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class SimplifiedRaProfileDto extends NameAndUuidDto {
 
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean enabled;
 
     @Schema(description = "Authority Instance UUID")

--- a/src/main/java/com/czertainly/api/model/common/AuthenticationServiceExceptionDto.java
+++ b/src/main/java/com/czertainly/api/model/common/AuthenticationServiceExceptionDto.java
@@ -5,11 +5,11 @@ import org.springframework.http.HttpStatus;
 
 public class AuthenticationServiceExceptionDto {
 
-    @Schema(description = "Status code of the HTTP Request", required = true)
+    @Schema(description = "Status code of the HTTP Request", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer statusCode;
-    @Schema(description = "Code of the result", required = true)
+    @Schema(description = "Code of the result", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
-    @Schema(description = "Exception message", required = true)
+    @Schema(description = "Exception message", requiredMode = Schema.RequiredMode.REQUIRED)
     private String message;
 
     public AuthenticationServiceExceptionDto(Integer statusCode, String code, String message) {

--- a/src/main/java/com/czertainly/api/model/common/BulkActionMessageDto.java
+++ b/src/main/java/com/czertainly/api/model/common/BulkActionMessageDto.java
@@ -6,7 +6,7 @@ public class BulkActionMessageDto extends NameAndUuidDto {
 
     @Schema(description = "Message describing the associations of the Objects which is preventing the bulk operation",
             example = "Object is associated with other items",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String message;
 
     public String getMessage() {

--- a/src/main/java/com/czertainly/api/model/common/ErrorMessageDto.java
+++ b/src/main/java/com/czertainly/api/model/common/ErrorMessageDto.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ErrorMessageDto {
 
     @Schema(description = "Error message detail",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "Error message")
     private String message;
 

--- a/src/main/java/com/czertainly/api/model/common/HealthDto.java
+++ b/src/main/java/com/czertainly/api/model/common/HealthDto.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class HealthDto {
 
     @Schema(description = "Current connector operational status",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private HealthStatus status;
 
     @Schema(description = "Detailed status description")

--- a/src/main/java/com/czertainly/api/model/common/HealthStatus.java
+++ b/src/main/java/com/czertainly/api/model/common/HealthStatus.java
@@ -15,7 +15,7 @@ public enum HealthStatus {
     UNKNOWN("unknown");
 
     @Schema(description = "Health Status",
-            example = "ok", required = true)
+            example = "ok", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     HealthStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/common/JwsBody.java
+++ b/src/main/java/com/czertainly/api/model/common/JwsBody.java
@@ -6,17 +6,17 @@ public class JwsBody {
 
     @Schema(
             description = "Protected field of JWS",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String protectedField;
     @Schema(
             description = "JWS payload",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String payload;
     @Schema(
             description = "JWS signature",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String signature;
 

--- a/src/main/java/com/czertainly/api/model/common/NameAndIdDto.java
+++ b/src/main/java/com/czertainly/api/model/common/NameAndIdDto.java
@@ -9,11 +9,11 @@ import java.io.Serializable;
 public class NameAndIdDto implements Serializable {
 
     @Schema(description = "Object identifier",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private int id;
 
     @Schema(description = "Object name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     public NameAndIdDto() {

--- a/src/main/java/com/czertainly/api/model/common/NameAndUuidDto.java
+++ b/src/main/java/com/czertainly/api/model/common/NameAndUuidDto.java
@@ -10,11 +10,11 @@ public class NameAndUuidDto implements Serializable {
 
     @Schema(description = "Object identifier",
             example = "7b55ge1c-844f-11dc-a8a3-0242ac120002",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String uuid;
     @Schema(description = "Object Name",
             example = "Name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String name;
 
     public NameAndUuidDto() {

--- a/src/main/java/com/czertainly/api/model/common/UuidDto.java
+++ b/src/main/java/com/czertainly/api/model/common/UuidDto.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class UuidDto {
 
     @Schema(description = "Object identifier",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeCallback.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeCallback.java
@@ -10,19 +10,19 @@ public class AttributeCallback {
 
     @Schema(
             description = "Context part of callback URL",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String callbackContext;
 
     @Schema(
             description = "HTTP method of the callback",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String callbackMethod;
 
     @Schema(
             description = "Mappings for the callback method",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Set<AttributeCallbackMapping> mappings;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeCallbackMapping.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeCallbackMapping.java
@@ -40,7 +40,7 @@ public class AttributeCallbackMapping {
     @Schema(
             description = "Name of the path variable or request param or body field" +
                     " which is to be used to assign value of attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String to;
 
@@ -49,7 +49,7 @@ public class AttributeCallbackMapping {
      **/
     @Schema(
             description = "Set of targets for propagating value.",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Set<AttributeValueTarget> targets;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeDefinition.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeDefinition.java
@@ -18,7 +18,7 @@ public class AttributeDefinition {
     @Schema(
             description = "UUID of the Attribute for unique identification",
             example = "166b5cf52-63f2-11ec-90d6-0242ac120003",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String uuid;
 
@@ -28,7 +28,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Name of the Attribute that is used for identification",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -46,7 +46,7 @@ public class AttributeDefinition {
    @Schema(
            description = "Friendly name of the the Attribute",
            example = "Attribute Name",
-           required = true
+           requiredMode = Schema.RequiredMode.REQUIRED
    )
    private String label;
 
@@ -55,7 +55,7 @@ public class AttributeDefinition {
      **/
     @Schema(
             description = "Type of the Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeType type;
 
@@ -65,7 +65,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Boolean determining if the Attribute is required. If true, the Attribute must be provided.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean required = false;
 
@@ -75,7 +75,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Boolean determining if the Attribute is read only. If true, the Attribute content cannot be changed.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean readOnly = false;
 
@@ -85,7 +85,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Boolean determining if the Attribute is visible and can be displayed, otherwise it should be hidden to the user.",
             defaultValue = "true",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean visible = true;
 
@@ -95,7 +95,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Boolean determining if the Attribute contains list of values in the content",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean list = false;
 
@@ -129,7 +129,7 @@ public class AttributeDefinition {
     @Schema(
             description = "Boolean determining if the Attribute can have multiple values",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean multiSelect = false;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeValueTarget.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/AttributeValueTarget.java
@@ -14,7 +14,7 @@ public enum AttributeValueTarget {
     REQUEST_PARAMETER("requestParameter"),
     BODY("body");
     @Schema(description = "Attribute value Target",
-            example = "pathVariable", required = true)
+            example = "pathVariable", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     AttributeValueTarget(String code) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/RequestAttributeCallback.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/RequestAttributeCallback.java
@@ -15,7 +15,7 @@ public class RequestAttributeCallback {
     private String uuid;
 
     @Schema(description = "Name of the Attribute",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/RequestAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/RequestAttributeDto.java
@@ -27,7 +27,7 @@ public class RequestAttributeDto {
     @Schema(
             description = "Name of the Attribute",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -36,7 +36,7 @@ public class RequestAttributeDto {
      **/
     @Schema(
             description = "Content of the Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Object content;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v1/ResponseAttributeDto.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v1/ResponseAttributeDto.java
@@ -29,7 +29,7 @@ public class ResponseAttributeDto {
     @Schema(
             description = "Name of the Attribute",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -39,7 +39,7 @@ public class ResponseAttributeDto {
    @Schema(
            description = "Label of the the Attribute",
            example = "Attribute Name",
-           required = true
+           requiredMode = Schema.RequiredMode.REQUIRED
    )
    private String label;
 
@@ -48,7 +48,7 @@ public class ResponseAttributeDto {
      **/
     @Schema(
             description = "Type of the Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeType type;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/BaseAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/BaseAttribute.java
@@ -26,7 +26,7 @@ public class BaseAttribute<T> extends AbstractBaseAttribute {
     @Schema(
             description = "UUID of the Attribute for unique identification",
             example = "166b5cf52-63f2-11ec-90d6-0242ac120003",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String uuid;
 
@@ -36,7 +36,7 @@ public class BaseAttribute<T> extends AbstractBaseAttribute {
     @Schema(
             description = "Name of the Attribute that is used for identification",
             example = "Attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String name;
 
@@ -58,7 +58,7 @@ public class BaseAttribute<T> extends AbstractBaseAttribute {
      */
     @Schema(
             description = "Type of the Attribute",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             defaultValue = "data"
     )
     private AttributeType type = AttributeType.DATA;

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/CustomAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/CustomAttribute.java
@@ -47,7 +47,7 @@ public class CustomAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Type of the Content",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeContentType contentType;
 
@@ -57,7 +57,7 @@ public class CustomAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Properties of the Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private CustomAttributeProperties properties;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/DataAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/DataAttribute.java
@@ -52,7 +52,7 @@ public class DataAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Type of the Content",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeContentType contentType;
 
@@ -62,7 +62,7 @@ public class DataAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Properties of the Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private DataAttributeProperties properties;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/InfoAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/InfoAttribute.java
@@ -24,7 +24,7 @@ public class InfoAttribute extends BaseAttribute<List<BaseAttributeContent>> {
     @Schema(
         description = "Content of the Attribute",
         type = "object",
-        required = true,
+        requiredMode = Schema.RequiredMode.REQUIRED,
         discriminatorProperty = "contentType",
         oneOf = {
             BooleanAttributeContent.class,
@@ -48,7 +48,7 @@ public class InfoAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Type of the Content",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeContentType contentType;
 
@@ -58,7 +58,7 @@ public class InfoAttribute extends BaseAttribute<List<BaseAttributeContent>> {
      */
     @Schema(
             description = "Properties of the Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private InfoAttributeProperties properties;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/MetadataAttribute.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/MetadataAttribute.java
@@ -19,7 +19,7 @@ public class MetadataAttribute extends BaseAttribute<List<BaseAttributeContent>>
     @Schema(
             description = "Content of the Attribute",
             type = "object",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             discriminatorProperty = "contentType",
             oneOf = {
                     BooleanAttributeContent.class,
@@ -43,7 +43,7 @@ public class MetadataAttribute extends BaseAttribute<List<BaseAttributeContent>>
      */
     @Schema(
             description = "Type of the Content",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private AttributeContentType contentType;
 
@@ -52,7 +52,7 @@ public class MetadataAttribute extends BaseAttribute<List<BaseAttributeContent>>
      */
     @Schema(
             description = "Properties of the Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private MetadataAttributeProperties properties;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeCallback.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeCallback.java
@@ -10,19 +10,19 @@ public class AttributeCallback {
 
     @Schema(
             description = "Context part of callback URL",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String callbackContext;
 
     @Schema(
             description = "HTTP method of the callback",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String callbackMethod;
 
     @Schema(
             description = "Mappings for the callback method",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Set<AttributeCallbackMapping> mappings;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeCallbackMapping.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeCallbackMapping.java
@@ -50,7 +50,7 @@ public class AttributeCallbackMapping {
     @Schema(
             description = "Name of the path variable or request param or body field" +
                     " which is to be used to assign value of attribute",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String to;
 
@@ -59,7 +59,7 @@ public class AttributeCallbackMapping {
      **/
     @Schema(
             description = "Set of targets for propagating value.",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Set<AttributeValueTarget> targets;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeValueTarget.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/AttributeValueTarget.java
@@ -17,7 +17,7 @@ public enum AttributeValueTarget {
 
 
     @Schema(description = "Attribute value Target",
-            example = "pathVariable", required = true)
+            example = "pathVariable", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     AttributeValueTarget(String code) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/RequestAttributeCallback.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/callback/RequestAttributeCallback.java
@@ -15,7 +15,7 @@ public class RequestAttributeCallback {
     private String uuid;
 
     @Schema(description = "Name of the Attribute",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/constraint/BaseAttributeConstraint.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/constraint/BaseAttributeConstraint.java
@@ -11,10 +11,10 @@ public class BaseAttributeConstraint<T> extends AttributeConstraint {
     @Schema(description = "Error message to be displayed for wrong data")
     private String errorMessage;
 
-    @Schema(description = "Attribute Constraint Type", required = true)
+    @Schema(description = "Attribute Constraint Type", requiredMode = Schema.RequiredMode.REQUIRED)
     private AttributeConstraintType type;
 
-    @Schema(description = "Attribute Constraint Data", required = true)
+    @Schema(description = "Attribute Constraint Data", requiredMode = Schema.RequiredMode.REQUIRED)
     private T data;
 
     public BaseAttributeConstraint(String description, String errorMessage, AttributeConstraintType type) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
@@ -8,7 +8,7 @@ public class BaseAttributeContent<T> extends AttributeContent {
     @Schema(description = "Content Reference")
     private String reference;
 
-    @Schema(description = "Content Data", required = true)
+    @Schema(description = "Content Data", requiredMode = Schema.RequiredMode.REQUIRED)
     private T data;
 
     public BaseAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BooleanAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BooleanAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class BooleanAttributeContent extends BaseAttributeContent<Boolean> {
 
-    @Schema(description = "Boolean attribute value", required = true)
+    @Schema(description = "Boolean attribute value", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean data;
 
     public BooleanAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/CredentialAttributeContent.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public class CredentialAttributeContent extends BaseAttributeContent<CredentialAttributeContentData> {
 
-    @Schema(description = "Credential attribute content data", required = true)
+    @Schema(description = "Credential attribute content data", requiredMode = Schema.RequiredMode.REQUIRED)
     private CredentialAttributeContentData data;
 
     public CredentialAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateAttributeContent.java
@@ -15,7 +15,7 @@ public class DateAttributeContent extends BaseAttributeContent<LocalDate> {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @JsonDeserialize(using = LocalDateDeserializer.class)
     @JsonSerialize(using = LocalDateSerializer.class)
-    @Schema(description = "Date attribute value in format yyyy-MM-dd", required = true)
+    @Schema(description = "Date attribute value in format yyyy-MM-dd", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDate data;
 
     public DateAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/DateTimeAttributeContent.java
@@ -15,7 +15,7 @@ public class DateTimeAttributeContent extends BaseAttributeContent<ZonedDateTime
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
     @JsonDeserialize(using = ZonedDateTimeDeserializer.class)
     @JsonSerialize(using = ZonedDateTimeSerializer.class)
-    @Schema(description = "DateTime attribute value in format yyyy-MM-ddTHH:mm:ss.SSSXXX", required = true)
+    @Schema(description = "DateTime attribute value in format yyyy-MM-ddTHH:mm:ss.SSSXXX", requiredMode = Schema.RequiredMode.REQUIRED)
     private ZonedDateTime data;
 
     public DateTimeAttributeContent(ZonedDateTime data) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FileAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FileAttributeContent.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FileAttributeContent extends BaseAttributeContent<FileAttributeContentData> {
 
-    @Schema(description = "File attribute content data", required = true)
+    @Schema(description = "File attribute content data", requiredMode = Schema.RequiredMode.REQUIRED)
     private FileAttributeContentData data;
 
     public FileAttributeContent(String reference, FileAttributeContentData data) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FloatAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/FloatAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class FloatAttributeContent extends BaseAttributeContent<Float> {
 
-    @Schema(description = "Float attribute value", required = true)
+    @Schema(description = "Float attribute value", requiredMode = Schema.RequiredMode.REQUIRED)
     private Float data;
 
     public FloatAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/IntegerAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/IntegerAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class IntegerAttributeContent extends BaseAttributeContent<Integer> {
 
-    @Schema(description = "Integer attribute value", required = true)
+    @Schema(description = "Integer attribute value", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer data;
 
     public IntegerAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/ObjectAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/ObjectAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class ObjectAttributeContent extends BaseAttributeContent<Object> {
 
-    @Schema(description = "Object attribute content data", required = true)
+    @Schema(description = "Object attribute content data", requiredMode = Schema.RequiredMode.REQUIRED)
     private Object data;
 
     public ObjectAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/SecretAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/SecretAttributeContent.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SecretAttributeContent extends BaseAttributeContent<SecretAttributeContentData> {
 
-    @Schema(description = "Secret attribute content data", required = true)
+    @Schema(description = "Secret attribute content data", requiredMode = Schema.RequiredMode.REQUIRED)
     private SecretAttributeContentData data;
 
     public SecretAttributeContent(String reference, SecretAttributeContentData data) {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/StringAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/StringAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class StringAttributeContent extends BaseAttributeContent<String> {
 
-    @Schema(description = "String attribute value", required = true)
+    @Schema(description = "String attribute value", requiredMode = Schema.RequiredMode.REQUIRED)
     private String data;
 
     public StringAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TextAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TextAttributeContent.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public class TextAttributeContent extends BaseAttributeContent<String> {
 
-    @Schema(description = "Text attribute value", required = true)
+    @Schema(description = "Text attribute value", requiredMode = Schema.RequiredMode.REQUIRED)
     private String data;
 
     public TextAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/TimeAttributeContent.java
@@ -15,7 +15,7 @@ public class TimeAttributeContent extends BaseAttributeContent<LocalTime> {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JsonSerialize(using = LocalTimeSerializer.class)
-    @Schema(description = "Time attribute value in format HH:mm:ss", required = true, implementation = String.class)
+    @Schema(description = "Time attribute value in format HH:mm:ss", requiredMode = Schema.RequiredMode.REQUIRED, implementation = String.class)
     private LocalTime data;
 
     public TimeAttributeContent() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/CredentialAttributeContentData.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/CredentialAttributeContentData.java
@@ -12,11 +12,11 @@ public class CredentialAttributeContentData extends NameAndUuidDto {
 
     @Schema(description = "Credential Kind",
             example = "SoftKeyStore, Basic, ApiKey, etc",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Credential Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<DataAttribute> attributes;
 
     public String getKind() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/FileAttributeContentData.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/data/FileAttributeContentData.java
@@ -9,13 +9,13 @@ import java.util.Objects;
 
 public class FileAttributeContentData {
 
-    @Schema(description = "File content", required = true)
+    @Schema(description = "File content", requiredMode = Schema.RequiredMode.REQUIRED)
     private String content;
 
-    @Schema(description = "Name of the file", required = true)
+    @Schema(description = "Name of the file", requiredMode = Schema.RequiredMode.REQUIRED)
     private String fileName;
 
-    @Schema(description = "Type of the file uploaded", required = true)
+    @Schema(description = "Type of the file uploaded", requiredMode = Schema.RequiredMode.REQUIRED)
     private MimeType mimeType;
 
     public FileAttributeContentData() {

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/BaseAttributeProperties.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/BaseAttributeProperties.java
@@ -12,7 +12,7 @@ public class BaseAttributeProperties {
     @Schema(
             description = "Friendly name of the the Attribute",
             example = "Attribute Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String label;
 
@@ -22,7 +22,7 @@ public class BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute is visible and can be displayed, otherwise it should be hidden to the user.",
             defaultValue = "true",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean visible = true;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/CustomAttributeProperties.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/CustomAttributeProperties.java
@@ -12,7 +12,7 @@ public class CustomAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute is required. If true, the Attribute must be provided.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean required = false;
 
@@ -22,7 +22,7 @@ public class CustomAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute is read only. If true, the Attribute content cannot be changed.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean readOnly = false;
 
@@ -33,7 +33,7 @@ public class CustomAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute contains list of values in the content",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean list = false;
 
@@ -43,7 +43,7 @@ public class CustomAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute can have multiple values",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean multiSelect = false;
 

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/DataAttributeProperties.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/properties/DataAttributeProperties.java
@@ -12,7 +12,7 @@ public class DataAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute is required. If true, the Attribute must be provided.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean required = false;
 
@@ -22,7 +22,7 @@ public class DataAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute is read only. If true, the Attribute content cannot be changed.",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean readOnly = false;
 
@@ -33,7 +33,7 @@ public class DataAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute contains list of values in the content",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean list = false;
 
@@ -43,7 +43,7 @@ public class DataAttributeProperties extends BaseAttributeProperties {
     @Schema(
             description = "Boolean determining if the Attribute can have multiple values",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean multiSelect = false;
 

--- a/src/main/java/com/czertainly/api/model/connector/authority/AuthorityProviderInstanceDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/authority/AuthorityProviderInstanceDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class AuthorityProviderInstanceDto extends NameAndUuidDto {
 
     @Schema(description = "List of Authority instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<BaseAttribute> attributes;
 
 

--- a/src/main/java/com/czertainly/api/model/connector/authority/AuthorityProviderInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/authority/AuthorityProviderInstanceRequestDto.java
@@ -10,15 +10,15 @@ import java.util.List;
 public class AuthorityProviderInstanceRequestDto {
 
     @Schema(description = "Authority instance name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Kind of Authority instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Authority instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceGroupsResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceGroupsResponseDto.java
@@ -9,13 +9,13 @@ List of groups information from the Compliance Provider. These groups will
 have name, uuid and the attributes.
  */
 public class ComplianceGroupsResponseDto {
-    @Schema(description = "UUID of the group", required = true, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
+    @Schema(description = "UUID of the group", requiredMode = Schema.RequiredMode.REQUIRED, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
     private String uuid;
 
-    @Schema(description = "Name of the group", required = true, example = "RFC")
+    @Schema(description = "Name of the group", requiredMode = Schema.RequiredMode.REQUIRED, example = "RFC")
     private String name;
 
-    @Schema(description = "Description of the group", required = false, example = "Sample description of the group")
+    @Schema(description = "Description of the group", requiredMode = Schema.RequiredMode.NOT_REQUIRED, example = "Sample description of the group")
     private String description;
 
     //Default getters and setters

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRequestDto.java
@@ -15,7 +15,7 @@ any incoming compliance check request
  */
 public class ComplianceRequestDto {
 
-    @Schema(description = "Base64 encoded Certificate content", required = true)
+    @Schema(description = "Base64 encoded Certificate content", requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificate;
 
     @Schema(description = "List of UUIDs of Compliance rules")

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRequestRulesDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRequestRulesDto.java
@@ -14,7 +14,7 @@ individual status.
  */
 public class ComplianceRequestRulesDto {
     @Schema(description = "UUID of the rule",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
     private String uuid;
 

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceResponseDto.java
@@ -14,7 +14,7 @@ by the Core from the Connector once the compliance check is completed.
  */
 public class ComplianceResponseDto {
 
-    @Schema(description = "Status of the compliance check", required = true, example = "ok")
+    @Schema(description = "Status of the compliance check", requiredMode = Schema.RequiredMode.REQUIRED, example = "ok")
     private ComplianceStatus status;
 
     @Schema(description = "List of rules applied and their status")

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceResponseRulesDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceResponseRulesDto.java
@@ -11,13 +11,13 @@ the ComplianceResponseDto and describes in detail the list of rules applied and 
 individual status.
  */
 public class ComplianceResponseRulesDto {
-    @Schema(description = "UUID of the rule", required = true, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
+    @Schema(description = "UUID of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
     private String uuid;
 
-    @Schema(description = "Name of the rule", required = true, example = "Rule1")
+    @Schema(description = "Name of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "Rule1")
     private String name;
 
-    @Schema(description = "Rule status", required = true, example = "ok")
+    @Schema(description = "Rule status", requiredMode = Schema.RequiredMode.REQUIRED, example = "ok")
     private ComplianceRuleStatus status;
 
     //Default getters and setters

--- a/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRulesResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/compliance/ComplianceRulesResponseDto.java
@@ -14,16 +14,16 @@ have name, uuid and the attributes. The attributes of the rules is used
 to request for additional information for the rule.
  */
 public class ComplianceRulesResponseDto {
-    @Schema(description = "UUID of the rule", required = true, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
+    @Schema(description = "UUID of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
     private String uuid;
 
     @Schema(description = "UUID of the group to which the rule belongs to", example = "166b5cf52-63f2-11ec-90d6-0242ac120003")
     private String groupUuid;
 
-    @Schema(description = "Name of the rule", required = true, example = "Rule1")
+    @Schema(description = "Name of the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "Rule1")
     private String name;
 
-    @Schema(description = "Type of the certificate to which this rule can be applied", required = true, example = "X509")
+    @Schema(description = "Type of the certificate to which this rule can be applied", requiredMode = Schema.RequiredMode.REQUIRED, example = "X509")
     private CertificateType certificateType;
 
     @Schema(description = "Rule attributes")

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/enums/TokenInstanceStatus.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/enums/TokenInstanceStatus.java
@@ -18,7 +18,7 @@ public enum TokenInstanceStatus {
     UNKNOWN("Unknown");
 
     @Schema(description = "Token instance status",
-            example = "ok", required = true)
+            example = "ok", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     TokenInstanceStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/CreateKeyRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/CreateKeyRequestDto.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class CreateKeyRequestDto {
 
     @Schema(description = "List of Token Profile Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> tokenProfileAttributes;
 
     @Schema(description = "List of Attributes to create a Key",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> createKeyAttributes;
 
 }

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/DestroyKeyRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/DestroyKeyRequestDto.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class DestroyKeyRequestDto {
 
     @Schema(description = "List of Token Profile Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> tokenProfileAttributes;
 
     @Schema(

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyData.java
@@ -22,25 +22,25 @@ public class KeyData {
 
     @Schema(
             description = "Type of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyType type;
 
     @Schema(
             description = "Cryptographic algorithm of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private CryptographicAlgorithm algorithm;
 
     @Schema(
             description = "Format of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyFormat format;
 
     @Schema(
             description = "Value of the Key",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             discriminatorProperty = "format",
             discriminatorMapping = {
                     @DiscriminatorMapping(value = "RAW", schema = RawKeyValue.class),
@@ -61,7 +61,7 @@ public class KeyData {
 
     @Schema(
             description = "Bit length of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int length;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyDataResponseDto.java
@@ -22,7 +22,7 @@ public class KeyDataResponseDto extends NameAndUuidDto {
 
     @Schema(
             description = "Data of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyData keyData;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyPairDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/KeyPairDataResponseDto.java
@@ -14,13 +14,13 @@ public class KeyPairDataResponseDto {
 
     @Schema(
             description = "Data of the Public Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyDataResponseDto publicKeyData;
 
     @Schema(
             description = "Data of the Private Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyDataResponseDto privateKeyData;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/CustomKeyValue.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/CustomKeyValue.java
@@ -15,7 +15,7 @@ public class CustomKeyValue extends KeyValue {
     @Schema(
             description = "Custom values associated with the Key. It can be anything specific to the implementation," +
                     "for example external ID, custom handlers, etc. Represented as a map of key-value pairs.",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private HashMap<String, String> values;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/EprkiKeyValue.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/EprkiKeyValue.java
@@ -12,7 +12,7 @@ public class EprkiKeyValue extends KeyValue {
 
     @Schema(
             description = "Base64 ASN.1 encoded EncryptedPrivateKeyInfo",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String value;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/PrkiKeyValue.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/PrkiKeyValue.java
@@ -12,7 +12,7 @@ public class PrkiKeyValue extends KeyValue {
 
     @Schema(
             description = "Base64 ASN.1 encoded PrivateKeyInfo",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String value;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/RawKeyValue.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/RawKeyValue.java
@@ -12,7 +12,7 @@ public class RawKeyValue extends KeyValue {
 
     @Schema(
             description = "Base64 raw value of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String value;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/SpkiKeyValue.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/key/value/SpkiKeyValue.java
@@ -12,7 +12,7 @@ public class SpkiKeyValue extends KeyValue {
 
     @Schema(
             description = "Base64 ASN.1 encoded SubjectPublicKeyInfo",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String value;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/CipherDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/CipherDataRequestDto.java
@@ -16,13 +16,13 @@ public class CipherDataRequestDto {
 
     @Schema(
             description = "List of cipher Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> cipherAttributes;
 
     @Schema(
             description = "Encrypted/decrypted data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<CipherRequestData> cipherData;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/DecryptDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/DecryptDataResponseDto.java
@@ -15,7 +15,7 @@ public class DecryptDataResponseDto {
 
     @Schema(
             description = "Decrypted data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<CipherResponseData> decryptedData;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/EncryptDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/EncryptDataResponseDto.java
@@ -15,7 +15,7 @@ public class EncryptDataResponseDto {
 
     @Schema(
             description = "Encrypted data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<CipherResponseData> encryptedData;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/RandomDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/RandomDataRequestDto.java
@@ -17,7 +17,7 @@ public class RandomDataRequestDto {
 
     @Schema(
             description = "Number of random bytes to generate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int length;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/RandomDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/RandomDataResponseDto.java
@@ -16,7 +16,7 @@ public class RandomDataResponseDto {
 
     @Schema(
             description = "Random generated data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] data;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/SignDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/SignDataResponseDto.java
@@ -15,7 +15,7 @@ public class SignDataResponseDto {
 
     @Schema(
             description = "Signatures",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<SignatureResponseData> signatures;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/SignatureDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/SignatureDataRequestDto.java
@@ -18,7 +18,7 @@ public class SignatureDataRequestDto {
 
     @Schema(
             description = "List of cipher Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> signatureAttributes;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/VerifyDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/VerifyDataRequestDto.java
@@ -15,7 +15,7 @@ public class VerifyDataRequestDto extends SignDataRequestDto {
 
     @Schema(
             description = "Signatures to verify",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<SignatureRequestData> signatures;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/VerifyDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/VerifyDataResponseDto.java
@@ -15,7 +15,7 @@ public class VerifyDataResponseDto {
 
     @Schema(
             description = "Signatures",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<VerificationResponseData> verifications;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/CipherRequestData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/CipherRequestData.java
@@ -16,7 +16,7 @@ public class CipherRequestData {
 
     @Schema(
             description = "Encrypted/decrypted data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] data;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/CipherResponseData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/CipherResponseData.java
@@ -14,7 +14,7 @@ public class CipherResponseData {
 
     @Schema(
             description = "Encrypted/decrypted data. In case operation failed, it should be null with provided details",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] data;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/SignatureRequestData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/SignatureRequestData.java
@@ -14,7 +14,7 @@ public class SignatureRequestData {
 
     @Schema(
             description = "Data to be signed or verified",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] data;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/SignatureResponseData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/SignatureResponseData.java
@@ -14,7 +14,7 @@ public class SignatureResponseData {
 
     @Schema(
             description = "Signature data",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] data;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/VerificationResponseData.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/operations/data/VerificationResponseData.java
@@ -14,7 +14,7 @@ public class VerificationResponseData {
 
     @Schema(
             description = "Data to be signed or verified",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean result;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceRequestDto.java
@@ -14,15 +14,15 @@ import java.util.List;
 public class TokenInstanceRequestDto {
 
     @Schema(description = "Token instance name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Kind of Token instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Token instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
 }

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceStatusComponent.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceStatusComponent.java
@@ -17,7 +17,7 @@ public class TokenInstanceStatusComponent {
 
     @Schema(
             description = "Token instance component status",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatus status;
 

--- a/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceStatusDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/cryptography/token/TokenInstanceStatusDto.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class TokenInstanceStatusDto {
 
     @Schema(description = "Token instance status",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private TokenInstanceStatus status;
 
     @Schema(description = "Components of the Token instance status")

--- a/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryDataRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryDataRequestDto.java
@@ -7,19 +7,19 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class DiscoveryDataRequestDto {
 
     @Schema(description = "Name of the Discovery",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Discovery Kind",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "Starting index of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer startIndex;
 
     @Schema(description = "Last index of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer endIndex;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryProviderCertificateDataDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryProviderCertificateDataDto.java
@@ -11,19 +11,19 @@ public class DiscoveryProviderCertificateDataDto {
 	
 	@Schema(
 			description = "Certificate UUID",
-			required = true
+			requiredMode = Schema.RequiredMode.REQUIRED
 	)
 	private String uuid;
 	
 	@Schema(
 			description = "Base64 encoded Certificate content",
-			required = true
+			requiredMode = Schema.RequiredMode.REQUIRED
 	)
 	private String base64Content;
 	
 	@Schema(
 			description = "Metadata for the Certificate",
-			required = true
+			requiredMode = Schema.RequiredMode.REQUIRED
 	)
 	private List<MetadataAttribute> meta;
 

--- a/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryProviderDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryProviderDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class DiscoveryProviderDto extends NameAndUuidDto {
 
 	@Schema(description = "Status of Discovery",
-			required = true)
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	private DiscoveryStatus status;
 	
 	@Schema(description = "Number of Certificates discovered",
@@ -20,11 +20,11 @@ public class DiscoveryProviderDto extends NameAndUuidDto {
 	private Integer totalCertificatesDiscovered;
 
 	@Schema(description = "Certificate data",
-			required = true)
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	private List<DiscoveryProviderCertificateDataDto> certificateData;
 	
 	@Schema(description = "Certificate Metadata",
-			required = true)
+			requiredMode = Schema.RequiredMode.REQUIRED)
 	private List<MetadataAttribute> meta;
 
 	public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/discovery/DiscoveryRequestDto.java
@@ -10,11 +10,11 @@ import java.util.List;
 public class DiscoveryRequestDto {
 
     @Schema(description = "Name of the Discovery",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Discovery Kind",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "Discovery Provider Attributes. Mandatory for creating new Discovery"

--- a/src/main/java/com/czertainly/api/model/connector/entity/CertificateLocationDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/CertificateLocationDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class CertificateLocationDto {
 
     @Schema(description = "Base64-encoded Certificate content",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateData;
 
     @Schema(
@@ -22,11 +22,11 @@ public class CertificateLocationDto {
 
     @Schema(description = "Type of the Certificate",
             defaultValue = "X509",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CertificateType certificateType;
 
     @Schema(description = "If the Certificate in Location has associated private key",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean withKey;
 
     @Schema(

--- a/src/main/java/com/czertainly/api/model/connector/entity/EntityInstanceDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/EntityInstanceDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class EntityInstanceDto extends NameAndUuidDto {
 
     @Schema(description = "List of Entity instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<BaseAttribute> attributes;
 
     public List<BaseAttribute> getAttributes() {

--- a/src/main/java/com/czertainly/api/model/connector/entity/EntityInstanceRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/EntityInstanceRequestDto.java
@@ -10,15 +10,15 @@ import java.util.List;
 public class EntityInstanceRequestDto {
 
     @Schema(description = "Entity instance name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Kind of Entity instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Entity instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/connector/entity/GenerateCsrRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/GenerateCsrRequestDto.java
@@ -11,17 +11,17 @@ public class GenerateCsrRequestDto {
 
     @Schema(
             description = "List of Location Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> locationAttributes;
 
     @Schema(
             description = "List of Attributes to generate CSR",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> csrAttributes;
 
-    @Schema(description = "Is the request for renewal of Certificate", required = true)
+    @Schema(description = "Is the request for renewal of Certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean renewal;
 
     public List<RequestAttributeDto> getLocationAttributes() {

--- a/src/main/java/com/czertainly/api/model/connector/entity/GenerateCsrResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/GenerateCsrResponseDto.java
@@ -12,19 +12,19 @@ import java.util.List;
 public class GenerateCsrResponseDto {
 
     @Schema(description = "Base64-encoded certificate signing request",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String csr;
 
     @Schema(description = "CSR Metadata")
     private List<MetadataAttribute> metadata;
 
     @Schema(description = "Type of the certificate expected to be issued",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CertificateType certificateType;
 
     @Schema(
             description = "List of Attributes to push Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> pushAttributes;
 

--- a/src/main/java/com/czertainly/api/model/connector/entity/LocationDetailRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/LocationDetailRequestDto.java
@@ -11,7 +11,7 @@ public class LocationDetailRequestDto {
 
     @Schema(
             description = "List of Location Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> locationAttributes;
 

--- a/src/main/java/com/czertainly/api/model/connector/entity/LocationDetailResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/LocationDetailResponseDto.java
@@ -11,27 +11,27 @@ public class LocationDetailResponseDto {
 
     @Schema(
             description = "List of Certificates in the Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<CertificateLocationDto> certificates;
 
     @Schema(
             description = "Location metadata",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private List<MetadataAttribute> metadata;
 
     @Schema(
             description = "Support for multiple Certificates in the Location",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean multipleEntries;
 
     @Schema(
             description = "Support for key pair management in the Location",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean supportKeyManagement;
 

--- a/src/main/java/com/czertainly/api/model/connector/entity/PushCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/PushCertificateRequestDto.java
@@ -12,25 +12,25 @@ public class PushCertificateRequestDto {
 
     @Schema(
             description = "Base64-encoded Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String certificate;
 
     @Schema(description = "Type of the Certificate",
             defaultValue = "X509",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private CertificateType certificateType;
 
     @Schema(
             description = "List of Location Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> locationAttributes;
 
     @Schema(
             description = "List of Attributes to push Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> pushAttributes;
 

--- a/src/main/java/com/czertainly/api/model/connector/entity/RemoveCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/RemoveCertificateRequestDto.java
@@ -10,13 +10,13 @@ public class RemoveCertificateRequestDto {
 
     @Schema(
             description = "Metadata of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MetadataAttribute> certificateMetadata;
 
     @Schema(
             description = "List of Location Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<RequestAttributeDto> locationAttributes;
 

--- a/src/main/java/com/czertainly/api/model/connector/entity/RemoveCertificateResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/entity/RemoveCertificateResponseDto.java
@@ -9,7 +9,7 @@ public class RemoveCertificateResponseDto {
 
     @Schema(
             description = "Metadata of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MetadataAttribute> certificateMetadata;
 

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertRevocationDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertRevocationDto.java
@@ -14,19 +14,19 @@ import java.util.List;
 public class CertRevocationDto {
 
     @Schema(description = "Revocation reason",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private RevocationReason reason;
 
     @Schema(description = "List of RA Profiles attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> raProfileAttributes;
 
     @Schema(description = "List of Attributes to revoke Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "Base64 Certificate content. (Certificate to be revoked)",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificate;
 
     public RevocationReason getReason() {

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateDataResponseDto.java
@@ -14,22 +14,22 @@ import java.util.List;
 public class CertificateDataResponseDto {
 
     @Schema(description = "Base64 encoded Certificate content",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateData;
 
     @Schema(description = "UUID of Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
     @Schema(
             description = "Metadata for the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MetadataAttribute> meta;
 
     @Schema(description = "Type of the Certificate",
             defaultValue = "X509",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private CertificateType certificateType;
 
     public String getCertificateData() {

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateRenewRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateRenewRequestDto.java
@@ -14,20 +14,20 @@ import java.util.List;
 public class CertificateRenewRequestDto {
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(description = "List of RA Profiles attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> raProfileAttributes;
 
     @Schema(description = "Base64 Certificate content. (Certificate to be renewed)",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificate;
 
     @Schema(
             description = "Metadata for the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MetadataAttribute> meta;
 

--- a/src/main/java/com/czertainly/api/model/connector/v2/CertificateSignRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/connector/v2/CertificateSignRequestDto.java
@@ -13,15 +13,15 @@ import java.util.List;
 public class CertificateSignRequestDto {
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(description = "List of RA Profiles attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> raProfileAttributes;
 
     @Schema(description = "List of Attributes to issue Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     public String getPkcs10() {

--- a/src/main/java/com/czertainly/api/model/core/acme/Account.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Account.java
@@ -18,7 +18,7 @@ public class Account {
      **/
     @Schema(
             description = "Status of the ACME Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "valid"
     )
     private AccountStatus status;
@@ -52,7 +52,7 @@ public class Account {
      */
     @Schema(
             description = "URL to get the list of Orders for the Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/orders/JHJGfgf34s"
 
     )

--- a/src/main/java/com/czertainly/api/model/core/acme/AcmeProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/AcmeProfileDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public class AcmeProfileDto extends NameAndUuidDto {
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean enabled;
     @Schema(description = "ACME Profile description", example = "Sample description")
     private String description;

--- a/src/main/java/com/czertainly/api/model/core/acme/AcmeProfileListDto.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/AcmeProfileListDto.java
@@ -8,7 +8,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class AcmeProfileListDto extends NameAndUuidDto {
 
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "false")
     private boolean enabled;
     @Schema(description = "ACME Profile description", example = "Some description")

--- a/src/main/java/com/czertainly/api/model/core/acme/Authorization.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Authorization.java
@@ -16,7 +16,7 @@ public class Authorization {
      */
     @Schema(
             description = "ACME Identifier",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Identifier identifier;
 
@@ -26,7 +26,7 @@ public class Authorization {
      */
     @Schema(
             description = "ACME Authorization status",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "pending"
     )
     private AuthorizationStatus status;

--- a/src/main/java/com/czertainly/api/model/core/acme/CertificateFinalizeRequest.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/CertificateFinalizeRequest.java
@@ -15,7 +15,7 @@ public class CertificateFinalizeRequest {
      */
     @Schema(
             description = "CSR in Base64url-encoded version of the DER format",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "<base64url-encoded version of the DER format>"
     )
     private String csr;

--- a/src/main/java/com/czertainly/api/model/core/acme/CertificateIssuanceRequest.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/CertificateIssuanceRequest.java
@@ -14,7 +14,7 @@ public class CertificateIssuanceRequest {
      * List of the Identifiers that the client wishes to submit an Order for.
      */
     @Schema(description = "List of Identifiers for the Order",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<Identifier> identifiers;
 
     /**

--- a/src/main/java/com/czertainly/api/model/core/acme/CertificateRevocationRequest.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/CertificateRevocationRequest.java
@@ -16,7 +16,7 @@ public class CertificateRevocationRequest {
      * uses base64url, and does not include headers, it is different from PEM.).
      */
     @Schema(description = "Certificate in base64url-encoded version of DER format",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "<base64url-encoded version of the DER format>")
     private String certificate;
 
@@ -26,7 +26,7 @@ public class CertificateRevocationRequest {
      * meaning the server can set the code for revocation is UNSPECIFIED.
      */
     @Schema(description = "Reason for revocation",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "1")
     private RevocationReason reason;
 

--- a/src/main/java/com/czertainly/api/model/core/acme/Challenge.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Challenge.java
@@ -12,7 +12,7 @@ public class Challenge {
      * Type of the Challenge encoded in the object.
      */
     @Schema(description = "Type of Challenge",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "dns-01")
     private ChallengeType type;
 
@@ -20,7 +20,7 @@ public class Challenge {
      * URL to which the response can be posted after the client completes the Challenge
      */
     @Schema(description = "URL to which the response can be posted after the client completes the Challenge",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "https://some-server.com/api/acme/chall/JHjhrt&6hf")
     private String url;
 
@@ -29,7 +29,7 @@ public class Challenge {
      * This is a mandatory field.
      */
     @Schema(description = "Challenge status",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private ChallengeStatus status;
 
     /**
@@ -52,7 +52,7 @@ public class Challenge {
      * Random string generated using the SecureRandom class of JAVA to provide a cryptography random key
      */
     @Schema(description = "Token for the Challenge",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "JGuyIUgkRGFYTER658ykjfYFur76fkFitur7FGHRiytrkfIruFF")
     private String token;
 

--- a/src/main/java/com/czertainly/api/model/core/acme/Directory.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Directory.java
@@ -13,7 +13,7 @@ public class Directory {
      * new Nonce values.
      */
     @Schema(description = "URL to get new Nonce",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/new-nonce")
     private String newNonce;
 
@@ -22,7 +22,7 @@ public class Directory {
      * new Account registration.
      */
     @Schema(description = "URL for the new Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/new-account")
     private String newAccount;
 
@@ -31,7 +31,7 @@ public class Directory {
      * new Order
      */
     @Schema(description = "URL for the new Order",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/new-order")
     private String newOrder;
 
@@ -40,7 +40,7 @@ public class Directory {
      * new Authz request
      */
     @Schema(description = "URL for the new Authorization",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/new-authz")
     private String newAuthz;
 
@@ -49,7 +49,7 @@ public class Directory {
      * new Certificate revocation
      */
     @Schema(description = "URL for revoking a certificate",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/revoke-cert")
     private String revokeCert;
 
@@ -58,7 +58,7 @@ public class Directory {
      * a new key change for an Account
      */
     @Schema(description = " URL for changing the key of an Account",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "http://some-server.com/acme/key-change")
     private String keyChange;
 
@@ -66,7 +66,7 @@ public class Directory {
      * Metadata for the Directory object. This will contain the metadata like termsOfService etc..
      */
     @Schema(description = "Metadata for the Directory object",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private DirectoryMeta meta;
 
     public String getNewNonce() {

--- a/src/main/java/com/czertainly/api/model/core/acme/DirectoryMeta.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/DirectoryMeta.java
@@ -32,7 +32,7 @@ public class DirectoryMeta {
      * CAA record validation list of hostnames
      */
     @Schema(description = "Array of CAA record validation servers",
-            required = false,
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED,
             example = "[\"example1.com\", \"example2.com\"]")
     private String[] caaIdentities;
 

--- a/src/main/java/com/czertainly/api/model/core/acme/Identifier.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Identifier.java
@@ -13,7 +13,7 @@ public class Identifier {
      * DNS Identifier types
      */
     @Schema(description = "Type of the Identifier",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "dns")
     private String type;
 
@@ -22,7 +22,7 @@ public class Identifier {
      * This field is the Identifier itself
      */
     @Schema(description = "Value of Identifier",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "www.some-domain.com")
     private String value;
 

--- a/src/main/java/com/czertainly/api/model/core/acme/KeyRollover.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/KeyRollover.java
@@ -3,9 +3,9 @@ package com.czertainly.api.model.core.acme;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class KeyRollover {
-    @Schema(description = "Account URL", example = "https://example.com/acme/acct/evOfKhNU60wg", required = true)
+    @Schema(description = "Account URL", example = "https://example.com/acme/acct/evOfKhNU60wg", requiredMode = Schema.RequiredMode.REQUIRED)
     private String account;
-    @Schema(description = "Old key of the Account", example = "<Account old key content>", required = true)
+    @Schema(description = "Old key of the Account", example = "<Account old key content>", requiredMode = Schema.RequiredMode.REQUIRED)
     private String oldKey;
 
     public String getAccount() {

--- a/src/main/java/com/czertainly/api/model/core/acme/Order.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/Order.java
@@ -17,7 +17,7 @@ public class Order {
      * This is a mandatory field
      */
     @Schema(description = "Status of the Order",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "pending")
     private OrderStatus status;
 

--- a/src/main/java/com/czertainly/api/model/core/acme/ProblemDocument.java
+++ b/src/main/java/com/czertainly/api/model/core/acme/ProblemDocument.java
@@ -19,7 +19,7 @@ public class ProblemDocument implements Serializable {
      * Type of the problem.
      */
     @Schema(description = "Type of the ACME problem",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "notFound")
     private String type;
 
@@ -33,7 +33,7 @@ public class ProblemDocument implements Serializable {
      * Details of the problem. These statements should be understandable by the user.
      */
     @Schema(description = "ACME problem details",
-            required = true, example = "Requested object is not found")
+            requiredMode = Schema.RequiredMode.REQUIRED, example = "Requested object is not found")
     private String detail;
 
     /**
@@ -41,7 +41,7 @@ public class ProblemDocument implements Serializable {
      * Terms of Service to be agreed by the client to continue with the ACME operations
      */
     @Schema(description = "URL of the changes if something needs to be approved",
-            required = true, example = "https://some-company.com/instances/changes")
+            requiredMode = Schema.RequiredMode.REQUIRED, example = "https://some-company.com/instances/changes")
     private String instance;
 
     /**

--- a/src/main/java/com/czertainly/api/model/core/audit/AuditLogDto.java
+++ b/src/main/java/com/czertainly/api/model/core/audit/AuditLogDto.java
@@ -15,55 +15,55 @@ public class AuditLogDto implements Identified {
 	
 	@Schema(
             description = "Audit log Id",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Long id;
 	
 	@Schema(
             description = "Audit log UUID",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String uuid;
 	
 	@Schema(
             description = "Requestor of the change",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String author;
 	
 	@Schema(
             description = "Time when the audit log is registered",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private LocalDateTime created;
 	
 	@Schema(
             description = "Status of the operation. Either success or failed",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private OperationStatusEnum operationStatus;
 	
 	@Schema(
             description = "Module triggered the action",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private ObjectType origination;
 	
 	@Schema(
             description = "Module affected by the operation",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private ObjectType affected;
 	
 	@Schema(
             description = "Object identifier",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String objectIdentifier;
 	
 	@Schema(
             description = "Type of operation performed",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private OperationType operation;
     @JsonRawValue

--- a/src/main/java/com/czertainly/api/model/core/audit/AuditLogResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/core/audit/AuditLogResponseDto.java
@@ -10,25 +10,25 @@ public class AuditLogResponseDto {
 	
 	@Schema(
             description = "Page number",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int page;
 	
 	@Schema(
             description = "Size of the data per page",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int size;
 	
 	@Schema(
             description = "Number of pages",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private int totalPages;
 	
 	@Schema(
             description = "Audit log items",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<AuditLogDto> items;
 

--- a/src/main/java/com/czertainly/api/model/core/audit/ExportResultDto.java
+++ b/src/main/java/com/czertainly/api/model/core/audit/ExportResultDto.java
@@ -8,13 +8,13 @@ public class ExportResultDto {
 	
 	@Schema(
             description = "Name of the file",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String fileName;
 	
 	@Schema(
             description = "File content in byte array",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private byte[] fileContent;
 

--- a/src/main/java/com/czertainly/api/model/core/auth/ActionDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ActionDto.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ActionDto extends NameAndUuidDto {
 
-    @Schema(description = "Resource label", required = true)
+    @Schema(description = "Resource label", requiredMode = Schema.RequiredMode.REQUIRED)
     private String displayName;
 
     public String getDisplayName() {

--- a/src/main/java/com/czertainly/api/model/core/auth/AuthenticationResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/AuthenticationResponseDto.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class AuthenticationResponseDto {
 
-    @Schema(description = "Is User Authenticated", required = true)
+    @Schema(description = "Is User Authenticated", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean authenticated;
 
     @Schema(description = "User profile data")

--- a/src/main/java/com/czertainly/api/model/core/auth/ObjectPermissionsDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ObjectPermissionsDto.java
@@ -8,16 +8,16 @@ import java.util.List;
 
 public class ObjectPermissionsDto {
 
-    @Schema(description = "UUID of the Object", required = true)
+    @Schema(description = "UUID of the Object", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "Name of the Object", required = true)
+    @Schema(description = "Name of the Object", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "Allowed Action list", required = true)
+    @Schema(description = "Allowed Action list", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> allow;
 
-    @Schema(description = "Denied Action list", required = true)
+    @Schema(description = "Denied Action list", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> deny;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/core/auth/ObjectPermissionsRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ObjectPermissionsRequestDto.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public class ObjectPermissionsRequestDto {
 
-    @Schema(description = "UUID of the Object", required = true)
+    @Schema(description = "UUID of the Object", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "Name of the Object", required = true)
+    @Schema(description = "Name of the Object", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Allowed Action list")

--- a/src/main/java/com/czertainly/api/model/core/auth/Resource.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/Resource.java
@@ -47,7 +47,7 @@ public enum Resource {
 
     @Schema(description = "Resource Name",
             example = "certificates",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
             
     private final String code;
 

--- a/src/main/java/com/czertainly/api/model/core/auth/ResourceDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ResourceDetailDto.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class ResourceDetailDto extends ResourceDto {
 
-    @Schema(description = "List of Actions for the Resource", required = true)
+    @Schema(description = "List of Actions for the Resource", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ActionDto> actions;
 
     public List<ActionDto> getActions() {

--- a/src/main/java/com/czertainly/api/model/core/auth/ResourceDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ResourceDto.java
@@ -9,17 +9,17 @@ public class ResourceDto extends NameAndUuidDto {
 
     @Schema(description = "Resource Name",
             example = "Name",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             implementation = Resource.class)
     protected String name;
 
-    @Schema(description = "Resource label", required = true)
+    @Schema(description = "Resource label", requiredMode = Schema.RequiredMode.REQUIRED)
     private String displayName;
 
     @Schema(description = "Listing Endpoint")
     private String listObjectsEndpoint;
 
-    @Schema(description = "If resource has Object access permissions. True = Yes, False = No", required = true)
+    @Schema(description = "If resource has Object access permissions. True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean objectAccess;
 
     public String getListObjectsEndpoint() {

--- a/src/main/java/com/czertainly/api/model/core/auth/ResourcePermissionsDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ResourcePermissionsDto.java
@@ -8,16 +8,16 @@ import java.util.List;
 
 public class ResourcePermissionsDto {
 
-    @Schema(description = "Name of the Resource", required = true)
+    @Schema(description = "Name of the Resource", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "Allow all actions. True = Yes, False = No", required = true)
+    @Schema(description = "Allow all actions. True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean allowAllActions;
 
-    @Schema(description = "List of actions permitted", required = true)
+    @Schema(description = "List of actions permitted", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> actions;
 
-    @Schema(description = "Object permissions", required = true)
+    @Schema(description = "Object permissions", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ObjectPermissionsDto> objects;
 
     public String getName() {

--- a/src/main/java/com/czertainly/api/model/core/auth/ResourcePermissionsRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/ResourcePermissionsRequestDto.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public class ResourcePermissionsRequestDto {
 
-    @Schema(description = "Name of the Resource", required = true)
+    @Schema(description = "Name of the Resource", requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
-    @Schema(description = "Allow all actions. True = Yes, False = No", required = true)
+    @Schema(description = "Allow all actions. True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean allowAllActions;
 
     @Schema(description = "List of actions permitted")

--- a/src/main/java/com/czertainly/api/model/core/auth/RoleDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/RoleDetailDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class RoleDetailDto extends RoleDto {
 
-    @Schema(description = "List of Users with the role", required = true)
+    @Schema(description = "List of Users with the role", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<UserDto> users;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/core/auth/RoleDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/RoleDto.java
@@ -9,7 +9,7 @@ public class RoleDto extends NameAndUuidDto {
     @Schema(description = "Description of the user")
     private String description;
 
-    @Schema(description = "Is system role. True = Yes, False = No", required = true)
+    @Schema(description = "Is system role. True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean systemRole;
 
     public Boolean getSystemRole() {

--- a/src/main/java/com/czertainly/api/model/core/auth/RolePermissionsRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/RolePermissionsRequestDto.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class RolePermissionsRequestDto {
 
-    @Schema(description = "Allow all resources, True = Yes, False = No", required = true)
+    @Schema(description = "Allow all resources, True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean allowAllResources;
 
     @Schema(description = "Resources")

--- a/src/main/java/com/czertainly/api/model/core/auth/SubjectPermissionsDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/SubjectPermissionsDto.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 public class SubjectPermissionsDto {
 
-    @Schema(description = "Allow all resources, True = Yes, False = No", required = true)
+    @Schema(description = "Allow all resources, True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean allowAllResources;
 
-    @Schema(description = "Resources", required = true)
+    @Schema(description = "Resources", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResourcePermissionsDto> resources;
 
     public Boolean getAllowAllResources() {

--- a/src/main/java/com/czertainly/api/model/core/auth/UpdateUserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UpdateUserRequestDto.java
@@ -12,18 +12,18 @@ public class UpdateUserRequestDto {
     @Schema(description = "Last name of the user")
     private String lastName;
 
-    @Schema(description = "Email of the user", required = true)
+    @Schema(description = "Email of the user", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
     @Schema(
             description = "Base64 Content of the admin certificate",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String certificateData;
 
     @Schema(
             description = "UUID of the existing certificate in the Inventory. Mandatory if certificate is not provided",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private String certificateUuid;
 

--- a/src/main/java/com/czertainly/api/model/core/auth/UserCertificateDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserCertificateDto.java
@@ -6,10 +6,10 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class UserCertificateDto {
 
-    @Schema(description = "UUID of the certificate", required = true)
+    @Schema(description = "UUID of the certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "Fingerprint of the certificate", required = true)
+    @Schema(description = "Fingerprint of the certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String fingerprint;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/core/auth/UserDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserDetailDto.java
@@ -12,7 +12,7 @@ public class UserDetailDto extends UserDto {
     @Schema(description = "User Certificate details")
     private UserCertificateDto certificate;
 
-    @Schema(description = "Roles for the user", required = true)
+    @Schema(description = "Roles for the user", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RoleDto> roles;
 
     @Schema(description = "List of Custom Attributes")

--- a/src/main/java/com/czertainly/api/model/core/auth/UserDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserDto.java
@@ -6,10 +6,10 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class UserDto {
 
-    @Schema(description = "UUID of the User", required = true, example = "5b5f0784-2519-11ed-861d-0242ac120002")
+    @Schema(description = "UUID of the User", requiredMode = Schema.RequiredMode.REQUIRED, example = "5b5f0784-2519-11ed-861d-0242ac120002")
     private String uuid;
 
-    @Schema(description = "Username of the user", required = true, example = "user1")
+    @Schema(description = "Username of the user", requiredMode = Schema.RequiredMode.REQUIRED, example = "user1")
     private String username;
 
     @Schema(description = "First name of the user")
@@ -24,10 +24,10 @@ public class UserDto {
     @Schema(description = "Description of the user")
     private String description;
 
-    @Schema(description = "Status of the user. True = Enabled, False = Disabled", required = true)
+    @Schema(description = "Status of the user. True = Enabled, False = Disabled", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean enabled;
 
-    @Schema(description = "Is System user. True = Yes, False = No", required = true)
+    @Schema(description = "Is System user. True = Yes, False = No", requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean systemUser;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/core/auth/UserProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserProfileDto.java
@@ -8,13 +8,13 @@ import java.util.List;
 
 public class UserProfileDto {
 
-    @Schema(description = "User details", required = true)
+    @Schema(description = "User details", requiredMode = Schema.RequiredMode.REQUIRED)
     private UserDto user;
 
-    @Schema(description = "User Roles", required = true)
+    @Schema(description = "User Roles", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> roles;
 
-    @Schema(description = "User Permissions", required = true)
+    @Schema(description = "User Permissions", requiredMode = Schema.RequiredMode.REQUIRED)
     private SubjectPermissionsDto permissions;
 
     public UserDto getUser() {

--- a/src/main/java/com/czertainly/api/model/core/auth/UserRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserRequestDto.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class UserRequestDto {
 
-    @Schema(description = "Username of the user", required = true, example = "user1")
+    @Schema(description = "Username of the user", requiredMode = Schema.RequiredMode.REQUIRED, example = "user1")
     private String username;
 
     @Schema(description = "First name of the user")

--- a/src/main/java/com/czertainly/api/model/core/auth/UserUpdateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/auth/UserUpdateRequestDto.java
@@ -12,7 +12,7 @@ public class UserUpdateRequestDto {
     @Schema(description = "Last name of the user")
     private String lastName;
 
-    @Schema(description = "Email of the user", required = true)
+    @Schema(description = "Email of the user", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
     @Schema(description = "Description of the user")

--- a/src/main/java/com/czertainly/api/model/core/authority/AddEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/AddEndEntityRequestDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class AddEndEntityRequestDto extends BaseEndEntityRequestDto {
 
     @Schema(description = "End Entity name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getUsername() {

--- a/src/main/java/com/czertainly/api/model/core/authority/AuthorityInstanceDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/AuthorityInstanceDto.java
@@ -12,27 +12,27 @@ import java.util.List;
 public class AuthorityInstanceDto extends NameAndUuidDto {
 
     @Schema(description = "List of Authority instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes;
 
     @Schema(description = "Status of Authority instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String status;
 
     @Schema(description = "UUID of Authority provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Name of Authority provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     @Schema(description = "Authority Instance Kind",
             example = "LegacyEjbca, ADCS, etc.",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     public List<ResponseAttributeDto> getAttributes() {

--- a/src/main/java/com/czertainly/api/model/core/authority/BaseEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/BaseEndEntityRequestDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class BaseEndEntityRequestDto {
 
     @Schema(description = "RA profile related to End Entity",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected RaProfileDto raProfile;
 
     @Schema(description = "End Entity email")
@@ -21,14 +21,14 @@ public class BaseEndEntityRequestDto {
     protected List<EndEntityExtendedInfoDto> extensionData;
 
     @Schema(description = "End Entity password",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String password;
 
     @Schema(description = "End Entity Subject alternative name")
     protected String subjectAltName;
 
     @Schema(description = "End Entity subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected String subjectDN;
 
     public RaProfileDto getRaProfile() {

--- a/src/main/java/com/czertainly/api/model/core/authority/CertRevocationDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/CertRevocationDto.java
@@ -10,15 +10,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class CertRevocationDto {
 
     @Schema(description = "Certificate serial number",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateSN;
 
     @Schema(description = "Issuer domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String issuerDN;
 
     @Schema(description = "Revocation reason",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private RevocationReason reason;
 
     public String getCertificateSN() {

--- a/src/main/java/com/czertainly/api/model/core/authority/CertificateSignRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/CertificateSignRequestDto.java
@@ -10,15 +10,15 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class CertificateSignRequestDto {
 
     @Schema(description = "End Entity password",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String password;
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(description = "End Entity username",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getPassword() {

--- a/src/main/java/com/czertainly/api/model/core/authority/CertificateSignResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/CertificateSignResponseDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class CertificateSignResponseDto {
 
     @Schema(description = "Base64 encoded Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateData;
 
     public String getCertificateData() {

--- a/src/main/java/com/czertainly/api/model/core/authority/EditEndEntityRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/EditEndEntityRequestDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class EditEndEntityRequestDto extends BaseEndEntityRequestDto {
 
     @Schema(description = "End Entity Subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected EndEntityStatus status;
 
     public EndEntityStatus getStatus() {

--- a/src/main/java/com/czertainly/api/model/core/authority/EndEntityDto.java
+++ b/src/main/java/com/czertainly/api/model/core/authority/EndEntityDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class EndEntityDto {
 
     @Schema(description = "End Entity subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String subjectDN;
 
     @Schema(description = "End Entity email")
@@ -26,11 +26,11 @@ public class EndEntityDto {
     private String subjectAltName;
 
     @Schema(description = "End Entity Subject domain name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private EndEntityStatus status;
 
     @Schema(description = "End Entity name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
     public String getSubjectDN() {

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateComplianceResultDto.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateComplianceResultDto.java
@@ -15,16 +15,16 @@ by the Core from the Connector once the compliance check is completed.
  */
 public class CertificateComplianceResultDto {
 
-    @Schema(description = "Name of the Compliance Provider", required = true, example = "Provider1")
+    @Schema(description = "Name of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED, example = "Provider1")
     private String connectorName;
 
-    @Schema(description = "Name of the rule",required = true, example = "RuleName")
+    @Schema(description = "Name of the rule",requiredMode = Schema.RequiredMode.REQUIRED, example = "RuleName")
     private String ruleName;
 
-    @Schema(description = "Description of the rule",required = true, example = "Description sample")
+    @Schema(description = "Description of the rule",requiredMode = Schema.RequiredMode.REQUIRED, example = "Description sample")
     private String ruleDescription;
 
-    @Schema(description = "Status of the rule",required = true, example = "nok")
+    @Schema(description = "Status of the rule",requiredMode = Schema.RequiredMode.REQUIRED, example = "nok")
     private ComplianceRuleStatus status;
 
     @Schema(description = "Attributes of the rule")

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateDto.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateDto.java
@@ -18,57 +18,57 @@ import java.util.Set;
 public class CertificateDto {
 
     @Schema(description = "UUID of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
     @Schema(description = "Certificate common name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String commonName;
     @Schema(description = "Certificate serial number",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String serialNumber;
     @Schema(description = "Certificate issuer common name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String issuerCommonName;
     @Schema(description = "Base64 encoded Certificate content",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateContent;
     @Schema(description = "Issuer DN of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String issuerDn;
     @Schema(description = "Subject DN of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String subjectDn;
     @Schema(description = "Certificate validity start date",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Date notBefore;
     @Schema(description = "Certificate expiration date",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Date notAfter;
     @Schema(description = "Public key algorithm",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String publicKeyAlgorithm;
     @Schema(description = "Certificate signature algorithm",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String signatureAlgorithm;
     @Schema(description = "Certificate key size",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer keySize;
     @Schema(description = "Extended key usages")
     private List<String> extendedKeyUsage;
     @Schema(description = "Key usages",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> keyUsage;
     @Schema(description = "Basic Constraints",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String basicConstraints;
     @Schema(description = "Certificate metadata")
     private List<MetadataResponseDto> metadata;
     @Schema(description = "Status of the Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private CertificateStatus status;
     @Schema(description = "RA Profile associated to the Certificate")
     private SimplifiedRaProfileDto raProfile;
-    @Schema(description = "SHA256 fingerprint of the Certificate", required = true)
+    @Schema(description = "SHA256 fingerprint of the Certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String fingerprint;
     @Schema(description = "Subject alternative names")
     private Map<String, Object> subjectAlternativeNames;

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateEvent.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateEvent.java
@@ -23,7 +23,7 @@ public enum CertificateEvent {
     ;
 
     @Schema(description = "Certificate Event",
-            example = "Issue Certificate", required = true)
+            example = "Issue Certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     CertificateEvent(String code) {

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateEventHistoryDto.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateEventHistoryDto.java
@@ -6,25 +6,25 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 
 public class CertificateEventHistoryDto {
-    @Schema(description = "UUID of the event", required = true)
+    @Schema(description = "UUID of the event", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "UUID of the Certificate", required = true)
+    @Schema(description = "UUID of the Certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateUuid;
 
-    @Schema(description = "Event creation time", required = true)
+    @Schema(description = "Event creation time", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime created;
 
-    @Schema(description = "Created By", required = true)
+    @Schema(description = "Created By", requiredMode = Schema.RequiredMode.REQUIRED)
     private String createdBy;
 
-    @Schema(description = "Event type", required = true)
+    @Schema(description = "Event type", requiredMode = Schema.RequiredMode.REQUIRED)
     private CertificateEvent event;
 
-    @Schema(description = "Event result", required = true)
+    @Schema(description = "Event result", requiredMode = Schema.RequiredMode.REQUIRED)
     private CertificateEventStatus status;
 
-    @Schema(description = "Event message", required = true)
+    @Schema(description = "Event message", requiredMode = Schema.RequiredMode.REQUIRED)
     private String message;
 
     @Schema(description = "Additional information for the event")

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateStatus.java
@@ -21,7 +21,7 @@ public enum CertificateStatus {
     ;
 
 	@Schema(description = "Certificate Status",
-			example = "valid", required = true)
+			example = "valid", requiredMode = Schema.RequiredMode.REQUIRED)
 	private String code;
 
 	CertificateStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateValidationStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateValidationStatus.java
@@ -19,7 +19,7 @@ public enum CertificateValidationStatus {
     EXPIRED("expired");
 
     @Schema(description = "Certificate Status",
-            example = "valid", required = true)
+            example = "valid", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     CertificateValidationStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/certificate/group/GroupRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/group/GroupRequestDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class GroupRequestDto {
 
     @Schema(description = "Name of the Certificate Group",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     @Schema(description = "Description of the Certificate Group")

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProfileDto.java
@@ -14,10 +14,10 @@ public class ComplianceProfileDto extends NameAndUuidDto {
     @Schema(description = "Description of the Compliance Profile")
     private String description;
 
-    @Schema(description = "List of rules", required = true)
+    @Schema(description = "List of rules", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ComplianceConnectorAndRulesDto> rules;
 
-    @Schema(description = "List of groups", required = true)
+    @Schema(description = "List of groups", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ComplianceConnectorAndGroupsDto> groups;
 
     @Schema(description = "List of associated RA Profiles")

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProfilesListDto.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProfilesListDto.java
@@ -12,7 +12,7 @@ public class ComplianceProfilesListDto extends NameAndUuidDto {
     @Schema(description = "Compliance Profile description")
     private String description;
 
-    @Schema(description = "Rules summary", required = true)
+    @Schema(description = "Rules summary", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ComplianceProviderSummaryDto> rules;
 
     //Default getters and setters

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProviderSummaryDto.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceProviderSummaryDto.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 public class ComplianceProviderSummaryDto {
-    @Schema(description = "Name of the Compliance Provider", required = true)
+    @Schema(description = "Name of the Compliance Provider", requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     @Schema(description = "Number of rules for the Provider")

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceRuleStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceRuleStatus.java
@@ -21,7 +21,7 @@ public enum ComplianceRuleStatus {
     NA("na"),
     ;
     @Schema(description = "Compliance Rule Status",
-            example = "ok", required = true)
+            example = "ok", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     ComplianceRuleStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceRulesDto.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceRulesDto.java
@@ -13,7 +13,7 @@ public class ComplianceRulesDto extends NameAndUuidDto {
     @Schema(description = "Description of the rule", example = "Sample rule description")
     private String description;
 
-    @Schema(description = "Certificate type for the rule", required = true, example = "X509")
+    @Schema(description = "Certificate type for the rule", requiredMode = Schema.RequiredMode.REQUIRED, example = "X509")
     private CertificateType certificateType;
 
     @Schema(description = "Attributes of the rule")

--- a/src/main/java/com/czertainly/api/model/core/compliance/ComplianceStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/compliance/ComplianceStatus.java
@@ -20,7 +20,7 @@ public enum ComplianceStatus {
     NA("na")
     ;
     @Schema(description = "Compliance Status",
-            example = "ok", required = true)
+            example = "ok", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     ComplianceStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/connector/BaseFunctionGroupDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/BaseFunctionGroupDto.java
@@ -7,16 +7,16 @@ import java.util.List;
 public class BaseFunctionGroupDto {
 
     @Schema(description = "Enumerated code of functional group",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected FunctionGroupCode functionGroupCode;
 
     @Schema(description = "List of supported functional group kinds",
             example = "[\"SoftKeyStore\", \"Basic\", \"ApiKey\"]",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected List<String> kinds;
 
     @Schema(description = "List of end points related to functional group",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     protected List<EndpointDto> endPoints;
 
     public BaseFunctionGroupDto() {

--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorDto.java
@@ -12,22 +12,22 @@ import java.util.List;
 public class ConnectorDto extends NameAndUuidDto implements Serializable {
 
     @Schema(description = "List of Function Groups implemented by the Connector",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<FunctionGroupDto> functionGroups;
     @Schema(description = "URL of the Connector",
             example = "http://network-discovery-provider:8080",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String url;
     @Schema(description = "Type of authentication for the Connector",
             example = "none",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private AuthType authType;
     @Schema(description = "List of Attributes for the authentication type",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<ResponseAttributeDto> authAttributes;
     @Schema(description = "Status of the Connector",
             example = "CONNECTED",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private ConnectorStatus status;
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes;

--- a/src/main/java/com/czertainly/api/model/core/connector/ConnectorStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/ConnectorStatus.java
@@ -18,7 +18,7 @@ public enum ConnectorStatus {
     ;
 
     @Schema(description = "Connector status",
-            example = "connected", required = true)
+            example = "connected", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     ConnectorStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/connector/EndpointDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/EndpointDto.java
@@ -11,19 +11,19 @@ public class EndpointDto extends NameAndUuidDto {
     @Schema(
             description = "Context of the Endpoint",
             example = "/v1",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String context;
     @Schema(
             description = "Method to be used for the Endpoint",
             example = "POST",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String method;
     @Schema(
             description = "True if the Endpoint is required for implementation",
             example = "true",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean required;
 

--- a/src/main/java/com/czertainly/api/model/core/connector/FunctionGroupCode.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/FunctionGroupCode.java
@@ -20,7 +20,7 @@ public enum FunctionGroupCode {
     CRYPTOGRAPHY_PROVIDER("cryptographyProvider");
 
     @Schema(description = "Function Group code of the Connector",
-            example = "credentialProvider", required = true)
+            example = "credentialProvider", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     FunctionGroupCode(String code) {

--- a/src/main/java/com/czertainly/api/model/core/connector/FunctionGroupDto.java
+++ b/src/main/java/com/czertainly/api/model/core/connector/FunctionGroupDto.java
@@ -8,10 +8,10 @@ public class FunctionGroupDto extends BaseFunctionGroupDto {
 
     @Schema(description = "UUID of the Function Group",
             example = "204a57f6-2ed3-45b6-bf09-af8b8c900e33",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
     @Schema(description = "Function Group Name",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String name;
 
     public String getUuid() {

--- a/src/main/java/com/czertainly/api/model/core/credential/CredentialDto.java
+++ b/src/main/java/com/czertainly/api/model/core/credential/CredentialDto.java
@@ -14,26 +14,26 @@ public class CredentialDto extends NameAndUuidDto implements Serializable {
 
     @Schema(description = "Credential Kind",
             example = "SoftKeyStore, Basic, ApiKey, etc",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     @Schema(description = "List of Credential Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes = new ArrayList<>();
 
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean enabled;
 
     @Schema(description = "UUID of Credential provider Connector",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Name of Credential provider Connector",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     public String getKind() {

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyDetailDto.java
@@ -40,7 +40,7 @@ public class KeyDetailDto extends KeyDto {
 
     @Schema(
             description = "Key Objects",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<KeyItemDto> items;
 }

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyDto.java
@@ -21,17 +21,17 @@ import java.time.LocalDateTime;
 public class KeyDto extends NameAndUuidDto {
 
     @Schema(description = "Description of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String description;
 
     @Schema(description = "Creation time of the Key. If the key is discovered from the connector, then it will be returned",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private LocalDateTime creationTime;
 
     @Schema(description = "Cryptographic algorithm of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private CryptographicAlgorithm cryptographicAlgorithm;
 
@@ -47,13 +47,13 @@ public class KeyDto extends NameAndUuidDto {
 
     @Schema(
             description = "Token Instance UUID",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceUuid;
 
     @Schema(
             description = "Token Instance Name",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceName;
 

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyEvent.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyEvent.java
@@ -22,7 +22,7 @@ public enum KeyEvent {
     ;
 
     @Schema(description = "Key Event",
-            example = "Create Key", required = true)
+            example = "Create Key", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     KeyEvent(String code) {

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyEventHistoryDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyEventHistoryDto.java
@@ -15,25 +15,25 @@ import java.util.HashMap;
 @Setter
 @ToString
 public class KeyEventHistoryDto {
-    @Schema(description = "UUID of the event", required = true)
+    @Schema(description = "UUID of the event", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
-    @Schema(description = "UUID of the Key", required = true)
+    @Schema(description = "UUID of the Key", requiredMode = Schema.RequiredMode.REQUIRED)
     private String keyUuid;
 
-    @Schema(description = "Event creation time", required = true)
+    @Schema(description = "Event creation time", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime created;
 
-    @Schema(description = "Created By", required = true)
+    @Schema(description = "Created By", requiredMode = Schema.RequiredMode.REQUIRED)
     private String createdBy;
 
-    @Schema(description = "Event type", required = true)
+    @Schema(description = "Event type", requiredMode = Schema.RequiredMode.REQUIRED)
     private KeyEvent event;
 
-    @Schema(description = "Event result", required = true)
+    @Schema(description = "Event result", requiredMode = Schema.RequiredMode.REQUIRED)
     private KeyEventStatus status;
 
-    @Schema(description = "Event message", required = true)
+    @Schema(description = "Event message", requiredMode = Schema.RequiredMode.REQUIRED)
     private String message;
 
     @Schema(description = "Additional information for the event")

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyItemDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyItemDto.java
@@ -24,19 +24,19 @@ public class KeyItemDto extends NameAndUuidDto {
 
     @Schema(
             description = "UUID of the key item in the Connector",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String keyReferenceUuid;
 
     @Schema(
             description = "Type of the Key",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyType type;
 
     @Schema(
             description = "Key Algorithm",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private CryptographicAlgorithm cryptographicAlgorithm;
 
@@ -57,19 +57,19 @@ public class KeyItemDto extends NameAndUuidDto {
 
     @Schema(
             description = "Key Usages",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<String> usage;
 
     @Schema(
             description = "Boolean describing if the key is enabled or not",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean enabled;
 
     @Schema(
             description = "Key State",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private KeyState state;
 }

--- a/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyState.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/key/KeyState.java
@@ -18,7 +18,7 @@ public enum KeyState {
     COMPROMISED_DESTROYED("compromisedDestroyed");
 
     @Schema(description = "Type of the key to be generated",
-            example = "secret", required = true)
+            example = "secret", requiredMode = Schema.RequiredMode.REQUIRED)
     private final String code;
 
     KeyState(String code) {

--- a/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceDetailDto.java
@@ -31,19 +31,19 @@ public class TokenInstanceDetailDto extends NameAndUuidDto {
 
     @Schema(
             description = "Status Of the Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatusDetailDto status;
 
     @Schema(
             description = "Number of Token Profiles associated",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Integer tokenProfiles;
 
     @Schema(
             description = "List of Token instance Attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<ResponseAttributeDto> attributes;
 

--- a/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceDto.java
@@ -18,13 +18,13 @@ public class TokenInstanceDto extends NameAndUuidDto {
 
     @Schema(
             description = "Status Of the Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatus status;
 
     @Schema(
             description = "Number of Token Profiles associated",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Integer tokenProfiles;
 

--- a/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceStatusDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/token/TokenInstanceStatusDetailDto.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class TokenInstanceStatusDetailDto {
     @Schema(
             description = "Token instance status",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatus status;
 

--- a/src/main/java/com/czertainly/api/model/core/cryptography/tokenprofile/TokenProfileDetailDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/tokenprofile/TokenProfileDetailDto.java
@@ -27,19 +27,19 @@ public class TokenProfileDetailDto extends NameAndUuidDto {
 
     @Schema(
             description = "UUID of Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceUuid;
 
     @Schema(
             description = "Name of Token instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceName;
 
     @Schema(
             description = "List of Token Profile attributes",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
@@ -50,19 +50,19 @@ public class TokenProfileDetailDto extends NameAndUuidDto {
 
     @Schema(
             description = "Token Instance Status",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatus tokenInstanceStatus;
 
     @Schema(
             description = "Enabled flag - true = enabled; false = disabled",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Boolean enabled;
 
     @Schema(
             description = "Usages for the Keys assoiated to the profile",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<KeyUsage> usages;
 }

--- a/src/main/java/com/czertainly/api/model/core/cryptography/tokenprofile/TokenProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/core/cryptography/tokenprofile/TokenProfileDto.java
@@ -22,25 +22,25 @@ public class TokenProfileDto extends NameAndUuidDto {
 
     @Schema(
             description = "UUID of Token Instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceUuid;
 
     @Schema(
             description = "Name of Token instance",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String tokenInstanceName;
 
     @Schema(
             description = "Token Instance Status",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private TokenInstanceStatus tokenInstanceStatus;
 
     @Schema(
             description = "Enabled flag - true = enabled; false = disabled",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private Boolean enabled;
 }

--- a/src/main/java/com/czertainly/api/model/core/discovery/DiscoveryCertificatesDto.java
+++ b/src/main/java/com/czertainly/api/model/core/discovery/DiscoveryCertificatesDto.java
@@ -15,31 +15,31 @@ import java.util.Date;
 @Setter
 @ToString
 public class DiscoveryCertificatesDto {
-    @Schema(description = "UUID of the Certificate", required = true)
+    @Schema(description = "UUID of the Certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
     @Schema(description = "UUID of the Certificate in Certificate inventory")
     private String inventoryUuid;
 
-    @Schema(description = "Certificate common name", required = true)
+    @Schema(description = "Certificate common name", requiredMode = Schema.RequiredMode.REQUIRED)
     private String commonName;
 
-    @Schema(description = "Certificate Serial Number", required = true)
+    @Schema(description = "Certificate Serial Number", requiredMode = Schema.RequiredMode.REQUIRED)
     private String serialNumber;
 
-    @Schema(description = "Issuer common name", required = true)
+    @Schema(description = "Issuer common name", requiredMode = Schema.RequiredMode.REQUIRED)
     private String issuerCommonName;
 
-    @Schema(description = "Certificate validity start date", required = true)
+    @Schema(description = "Certificate validity start date", requiredMode = Schema.RequiredMode.REQUIRED)
     private Date notBefore;
 
-    @Schema(description = "Certificate expiration date", required = true)
+    @Schema(description = "Certificate expiration date", requiredMode = Schema.RequiredMode.REQUIRED)
     private Date notAfter;
 
-    @Schema(description = "SHA256 thumbprint of the certificate", required = true)
+    @Schema(description = "SHA256 thumbprint of the certificate", requiredMode = Schema.RequiredMode.REQUIRED)
     private String fingerprint;
 
-    @Schema(description = "Base64 encoded Certificate content", required = true)
+    @Schema(description = "Base64 encoded Certificate content", requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateContent;
 
 }

--- a/src/main/java/com/czertainly/api/model/core/discovery/DiscoveryStatus.java
+++ b/src/main/java/com/czertainly/api/model/core/discovery/DiscoveryStatus.java
@@ -17,7 +17,7 @@ public enum DiscoveryStatus {
     WARNING("warning")
     ;
     @Schema(description = "Discovery Status",
-            example = "completed", required = true)
+            example = "completed", requiredMode = Schema.RequiredMode.REQUIRED)
     private String code;
 
     DiscoveryStatus(String code) {

--- a/src/main/java/com/czertainly/api/model/core/entity/EntityInstanceDto.java
+++ b/src/main/java/com/czertainly/api/model/core/entity/EntityInstanceDto.java
@@ -12,27 +12,27 @@ import java.util.List;
 public class EntityInstanceDto extends NameAndUuidDto {
 
     @Schema(description = "List of Entity instance Attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes;
 
     @Schema(description = "Status of Entity instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String status;
 
     @Schema(description = "UUID of Entity Provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorUuid;
 
     @Schema(description = "Name of Entity Provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String connectorName;
 
     @Schema(description = "Entity instance Kind",
             example = "Keystore, etc.",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String kind;
 
     public List<ResponseAttributeDto> getAttributes() {

--- a/src/main/java/com/czertainly/api/model/core/location/CertificateInLocationDto.java
+++ b/src/main/java/com/czertainly/api/model/core/location/CertificateInLocationDto.java
@@ -10,25 +10,25 @@ public class CertificateInLocationDto {
 
     @Schema(
             description = "UUID of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String certificateUuid;
 
     @Schema(
             description = "Common Name of the Subject DN field of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String commonName;
 
     @Schema(
             description = "Serial number in HEX of the Certificate",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String serialNumber;
 
     @Schema(
             description = "Metadata of the Certificate in Location",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<MetadataResponseDto> metadata;
 
@@ -45,7 +45,7 @@ public class CertificateInLocationDto {
     @Schema(
             description = "If the Certificate in Location has associated private key",
             defaultValue = "false",
-            required = false
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     private boolean withKey;
 

--- a/src/main/java/com/czertainly/api/model/core/location/LocationDto.java
+++ b/src/main/java/com/czertainly/api/model/core/location/LocationDto.java
@@ -19,38 +19,38 @@ public class LocationDto extends NameAndUuidDto {
     private String description;
 
     @Schema(description = "UUID of Entity instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String entityInstanceUuid;
 
     @Schema(description = "Name of Entity instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String entityInstanceName;
 
     @Schema(description = "List of Location attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes;
 
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean enabled;
 
     @Schema(description = "If the location supports multiple Certificates",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean supportMultipleEntries;
 
     @Schema(description = "If the location supports key management operations",
             defaultValue = "false",
-            required = true
+            requiredMode = Schema.RequiredMode.REQUIRED
     )
     private boolean supportKeyManagement;
 
     @Schema(description = "List of Certificates in Location",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<CertificateInLocationDto> certificates;
 
     @Schema(description = "Location metadata")

--- a/src/main/java/com/czertainly/api/model/core/raprofile/RaProfileDto.java
+++ b/src/main/java/com/czertainly/api/model/core/raprofile/RaProfileDto.java
@@ -18,26 +18,26 @@ public class RaProfileDto extends NameAndUuidDto {
     private String description;
 
     @Schema(description = "UUID of Authority provider",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String authorityInstanceUuid;
 
     @Schema(description = "Name of Authority instance",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String authorityInstanceName;
 
     @Schema(description = "List of RA Profiles attributes",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<ResponseAttributeDto> attributes = new ArrayList<>();
 
     @Schema(description = "List of Custom Attributes")
     private List<ResponseAttributeDto> customAttributes;
 
     @Schema(description = "Enabled flag - true = enabled; false = disabled",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private Boolean enabled;
 
     @Schema(description = "List of protocols enabled",
-            required = false)
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private List<String> enabledProtocols;
 
     @Override

--- a/src/main/java/com/czertainly/api/model/core/search/DynamicSearchInternalResponse.java
+++ b/src/main/java/com/czertainly/api/model/core/search/DynamicSearchInternalResponse.java
@@ -3,11 +3,11 @@ package com.czertainly.api.model.core.search;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public class DynamicSearchInternalResponse {
-    @Schema(description = "Number of items matching the filter", required = true)
+    @Schema(description = "Number of items matching the filter", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long totalItems;
-    @Schema(description = "Number of pages", required = true)
+    @Schema(description = "Number of pages", requiredMode = Schema.RequiredMode.REQUIRED)
     private Integer totalPages;
-    @Schema(description = "Search result", required = true)
+    @Schema(description = "Search result", requiredMode = Schema.RequiredMode.REQUIRED)
     private Object result;
 
     public Long getTotalItems() {

--- a/src/main/java/com/czertainly/api/model/core/search/SearchFieldDataDto.java
+++ b/src/main/java/com/czertainly/api/model/core/search/SearchFieldDataDto.java
@@ -6,19 +6,19 @@ import java.util.List;
 
 public class SearchFieldDataDto {
     @Schema(description = "Field to search",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private SearchableFields field;
 
     @Schema(description = "Label for the field",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String label;
 
     @Schema(description = "Type of the field",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private SearchableFieldType type;
 
     @Schema(description = "List of available conditions for the field",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<SearchCondition> conditions;
 
     @Schema(description = "Available values for the field")

--- a/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateDataResponseDto.java
+++ b/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateDataResponseDto.java
@@ -10,11 +10,11 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientCertificateDataResponseDto {
 
     @Schema(description = "Base64 encoded Certificate content",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String certificateData;
 
     @Schema(description = "UUID of Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String uuid;
 
     public String getCertificateData() {

--- a/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRenewRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRenewRequestDto.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class ClientCertificateRenewRequestDto {
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(

--- a/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRevocationDto.java
+++ b/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRevocationDto.java
@@ -14,11 +14,11 @@ import java.util.List;
 public class ClientCertificateRevocationDto {
 
     @Schema(description = "Reason for revocation",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private RevocationReason reason;
 
     @Schema(description = "List of Attributes to revoke Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     public RevocationReason getReason() {

--- a/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateSignRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateSignRequestDto.java
@@ -13,11 +13,11 @@ import java.util.List;
 public class ClientCertificateSignRequestDto {
 
     @Schema(description = "Certificate sign request (PKCS#10) encoded as Base64 string",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private String pkcs10;
 
     @Schema(description = "List of Attributes to issue Certificate",
-            required = true)
+            requiredMode = Schema.RequiredMode.REQUIRED)
     private List<RequestAttributeDto> attributes;
 
     @Schema(description = "List of Custom Attributes")


### PR DESCRIPTION
- swagger annotation library needs to be updated to work with springdoc-openapi v2
- replace deprecated Schema property required in all DTOs