### PR TITLE
Add endpoints for the management of individual custom attributes per objects

### DIFF
--- a/src/main/java/com/czertainly/api/interfaces/core/web/CustomAttributeController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/CustomAttributeController.java
@@ -3,6 +3,8 @@ package com.czertainly.api.interfaces.core.web;
 import com.czertainly.api.exception.AlreadyExistException;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.client.attribute.AttributeDefinitionDto;
+import com.czertainly.api.model.client.attribute.RequestAttributeDto;
+import com.czertainly.api.model.client.attribute.ResponseAttributeDto;
 import com.czertainly.api.model.client.attribute.custom.CustomAttributeCreateRequestDto;
 import com.czertainly.api.model.client.attribute.custom.CustomAttributeDefinitionDetailDto;
 import com.czertainly.api.model.client.attribute.custom.CustomAttributeUpdateRequestDto;
@@ -11,6 +13,7 @@ import com.czertainly.api.model.common.ErrorMessageDto;
 import com.czertainly.api.model.common.UuidDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
 import com.czertainly.api.model.common.attribute.v2.CustomAttribute;
+import com.czertainly.api.model.common.attribute.v2.content.BaseAttributeContent;
 import com.czertainly.api.model.core.auth.Resource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,6 +25,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -146,4 +150,31 @@ public interface CustomAttributeController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Custom Attribute retrieved")})
     @RequestMapping(path = "/resources", method = RequestMethod.GET, produces = {"application/json"})
     List<Resource> getResources();
+
+    @Operation(summary = "Update Value of a Custom Attribute for a Resource")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Custom Attribute value updated")})
+    @RequestMapping(
+            path = "/resources/{resourceName}/objects/{objectUuid}/{attributeUuid}",
+            method = RequestMethod.PATCH,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    List<ResponseAttributeDto> updateAttributeContentForResource(
+            @Parameter(description = "Resource Type") @PathVariable Resource resourceName,
+            @Parameter(description = "Object UUID") @PathVariable String objectUuid,
+            @Parameter(description = "Custom Attribute UUID") @PathVariable String attributeUuid,
+            @RequestBody List<BaseAttributeContent> request
+            ) throws NotFoundException;
+
+    @Operation(summary = "Delete Value of a Custom Attribute for a Resource")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Custom Attribute value deleted")})
+    @RequestMapping(
+            path = "/resources/{resourceName}/objects/{objectUuid}/{attributeUuid}",
+            method = RequestMethod.DELETE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    List<ResponseAttributeDto> deleteAttributeContentForResource(
+            @Parameter(description = "Resource Type") @PathVariable Resource resourceName,
+            @Parameter(description = "Object UUID") @PathVariable String objectUuid,
+            @Parameter(description = "Custom Attribute UUID") @PathVariable String attributeUuid
+    ) throws NotFoundException;
 }

--- a/src/main/java/com/czertainly/api/model/client/certificate/UploadCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/certificate/UploadCertificateRequestDto.java
@@ -1,31 +1,26 @@
 package com.czertainly.api.model.client.certificate;
 
+import com.czertainly.api.model.client.attribute.RequestAttributeDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Data;
+
+import java.util.List;
 
 /**
  * Class representing new certificate upload request
  */
+@Data
 public class UploadCertificateRequestDto {
-	
-	@Schema(
+
+    @Schema(
             description = "Base64 Content of the Certificate",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-	private String certificate;
+    private String certificate;
 
-	public String getCertificate() {
-		return certificate;
-	}
-
-	public void setCertificate(String certificate) {
-		this.certificate = certificate;
-	}
-
-	@Override
-	public String toString() {
-		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("certificate", certificate)
-				.toString();
-	}
+    @Schema(
+            description = "Custom Attributes for the Certificate",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private List<RequestAttributeDto> customAttributes;
 }

--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -797,7 +797,7 @@ public class AttributeDefinitionUtils {
                 atr.setContentType(clt.getContentType());
                 convertedDefinition.add(atr);
             }
-        } if (attributes.get(0) instanceof CustomAttribute) {
+        } else if (attributes.get(0) instanceof CustomAttribute) {
             List<CustomAttribute> itrAttributes = (List<CustomAttribute>) attributes;
             for (CustomAttribute clt : itrAttributes) {
                 if (clt.getProperties() == null) {

--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -8,6 +8,7 @@ import com.czertainly.api.model.common.NameAndIdDto;
 import com.czertainly.api.model.common.NameAndUuidDto;
 import com.czertainly.api.model.common.attribute.v2.AttributeType;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
+import com.czertainly.api.model.common.attribute.v2.CustomAttribute;
 import com.czertainly.api.model.common.attribute.v2.DataAttribute;
 import com.czertainly.api.model.common.attribute.v2.callback.AttributeCallback;
 import com.czertainly.api.model.common.attribute.v2.callback.AttributeCallbackMapping;
@@ -19,6 +20,7 @@ import com.czertainly.api.model.common.attribute.v2.constraint.data.DateTimeAttr
 import com.czertainly.api.model.common.attribute.v2.constraint.data.RangeAttributeConstraintData;
 import com.czertainly.api.model.common.attribute.v2.content.*;
 import com.czertainly.api.model.common.attribute.v2.content.data.CredentialAttributeContentData;
+import com.czertainly.api.model.common.attribute.v2.properties.CustomAttributeProperties;
 import com.czertainly.api.model.common.attribute.v2.properties.DataAttributeProperties;
 import com.czertainly.api.model.core.credential.CredentialDto;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -785,6 +787,21 @@ public class AttributeDefinitionUtils {
             for (DataAttribute clt : itrAttributes) {
                 if (clt.getProperties() == null) {
                     clt.setProperties(new DataAttributeProperties());
+                }
+                ResponseAttributeDto atr = new ResponseAttributeDto();
+                atr.setContent(clt.getContent());
+                atr.setName(clt.getName());
+                atr.setUuid(clt.getUuid());
+                atr.setLabel(clt.getProperties().getLabel());
+                atr.setType(clt.getType());
+                atr.setContentType(clt.getContentType());
+                convertedDefinition.add(atr);
+            }
+        } if (attributes.get(0) instanceof CustomAttribute) {
+            List<CustomAttribute> itrAttributes = (List<CustomAttribute>) attributes;
+            for (CustomAttribute clt : itrAttributes) {
+                if (clt.getProperties() == null) {
+                    clt.setProperties(new CustomAttributeProperties());
                 }
                 ResponseAttributeDto atr = new ResponseAttributeDto();
                 atr.setContent(clt.getContent());


### PR DESCRIPTION
This PR contains the following changes:

1. Add endpoints for the management of individual custom attributes per objects
2. Add Custom Attribute Response Attribute converter
3. Add custom attribute while uploading the certificate