### PR TITLE
Add key usages for token profile when creating and editing keys

### DIFF
--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/AddTokenProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/AddTokenProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.czertainly.api.model.client.cryptography.tokenprofile;
 
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -43,4 +44,9 @@ public class AddTokenProfileRequestDto {
             defaultValue = "false"
     )
     private boolean enabled;
+
+    @Schema(
+            description = "Usages for the Key"
+    )
+    private List<KeyUsage> usage;
 }

--- a/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/EditTokenProfileRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/client/cryptography/tokenprofile/EditTokenProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.czertainly.api.model.client.cryptography.tokenprofile;
 
 import com.czertainly.api.model.client.attribute.RequestAttributeDto;
+import com.czertainly.api.model.core.cryptography.key.KeyUsage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -33,4 +34,9 @@ public class EditTokenProfileRequestDto {
             description = "Enabled flag - true = enabled; false = disabled"
     )
     private Boolean enabled;
+
+    @Schema(
+            description = "Usages for the Key"
+    )
+    private List<KeyUsage> usage;
 }


### PR DESCRIPTION
This PR contains the change for the following:

1. When a new Token Profile is added, it should also contain the list of usages in the request and edit request DTO.