### PR TITLE
Fix validation of attributes

### DIFF
--- a/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
+++ b/src/main/java/com/czertainly/core/util/AttributeDefinitionUtils.java
@@ -315,11 +315,8 @@ public class AttributeDefinitionUtils {
                     label = customAttribute.getProperties().getLabel();
                 }
             } else {
-                throw new ValidationException(
-                        ValidationError.create(
-                                "Cannot validate " + definition.getType() + " attributes"
-                        )
-                );
+                logger.warn("Cannot validate " + definition.getType() + " attributes");
+                continue;
             }
 
             if (attribute == null) {


### PR DESCRIPTION
When an attribute that is of type other than data and custom, do not throw exception