### PR TITLE
Implement creation of CSR without Issuing the certificate

### DIFF
--- a/src/main/java/com/czertainly/api/interfaces/core/web/CertificateController.java
+++ b/src/main/java/com/czertainly/api/interfaces/core/web/CertificateController.java
@@ -9,13 +9,11 @@ import com.czertainly.api.model.common.BulkActionMessageDto;
 import com.czertainly.api.model.common.ErrorMessageDto;
 import com.czertainly.api.model.common.UuidDto;
 import com.czertainly.api.model.common.attribute.v2.BaseAttribute;
-import com.czertainly.api.model.core.certificate.CertificateContentDto;
-import com.czertainly.api.model.core.certificate.CertificateDetailDto;
-import com.czertainly.api.model.core.certificate.CertificateEventHistoryDto;
-import com.czertainly.api.model.core.certificate.CertificateValidationDto;
+import com.czertainly.api.model.core.certificate.*;
 import com.czertainly.api.model.core.location.LocationDto;
 import com.czertainly.api.model.core.search.SearchFieldDataByGroupDto;
 import com.czertainly.api.model.core.search.SearchFieldDataDto;
+import com.czertainly.api.model.core.v2.ClientCertificateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -26,11 +24,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Map;
@@ -190,4 +191,20 @@ public interface CertificateController {
             description = "Certificate UUIDs", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)),
             examples = {@ExampleObject(value = "[\"c2f685d4-6a3e-11ec-90d6-0242ac120003\",\"b9b09548-a97c-4c6a-a06a-e4ee6fc2da98\"]")}))
                                                       @RequestBody List<String> uuids);
+
+    @Operation(
+            summary = "Generate CSR Entity"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "CSR Generated and ready to be issued")
+    })
+    @RequestMapping(
+            path = "/create",
+            method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    CertificateDetailDto createCsr(
+            @RequestBody ClientCertificateRequestDto request
+    ) throws ValidationException, NotFoundException, CertificateException, IOException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException;
 }

--- a/src/main/java/com/czertainly/api/model/core/certificate/CertificateEvent.java
+++ b/src/main/java/com/czertainly/api/model/core/certificate/CertificateEvent.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 
 public enum CertificateEvent {
     ISSUE("Issue Certificate"),
+    CREATE_CSR("Create CSR"),
     RENEW("Renew Certificate"),
     REVOKE("Revoke Certificate"),
     DELETE("Delete Certificate"),

--- a/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRequestDto.java
+++ b/src/main/java/com/czertainly/api/model/core/v2/ClientCertificateRequestDto.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @ToString
-public class ClientCertificateSignRequestDto {
+public class ClientCertificateRequestDto {
 
     @Schema(
             description = "List of attributes to create CSR. Required if CSR is not provided"
@@ -51,24 +51,8 @@ public class ClientCertificateSignRequestDto {
     // Attributes
     //------------------------------------------------------------------------------------------------------------------
     @Schema(
-            description = "List of RA Profile related Attributes to issue Certificate",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private List<RequestAttributeDto> attributes;
-
-    @Schema(
             description = "List of Custom Attributes"
     )
     private List<RequestAttributeDto> customAttributes;
-
-    //------------------------------------------------------------------------------------------------------------------
-    // Existing Certificate Entity
-    // Set the UUID of the following property to the existing certificate that is in the New state and ready to be issued
-    //------------------------------------------------------------------------------------------------------------------
-
-    @Schema(
-            description = "UUID of CSR Entity to be signed"
-    )
-    private UUID uuid;
 
 }


### PR DESCRIPTION
This PR Contains the changes for the following:

1. Include a new API to create the CSR without issuing the certificate
2. Add API to issue the certificate from the saved CSR
3. Add DTO for the above operations