### PR TITLE
Fix equals method of BaseAttributeContent

### DIFF
--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
@@ -47,9 +47,9 @@ public class BaseAttributeContent<T> extends AttributeContent {
         if (o == null) return false;
         if (this == o) return true;
         BaseAttributeContent<?> that = (BaseAttributeContent<?>) o;
-        boolean referenceEquals = Objects.equals(this.reference, that.getReference());
 
-        return referenceEquals ? Objects.equals(this.data, that.getData()) : referenceEquals;
+        // content is considered equal when reference and data are equal
+        return Objects.equals(this.reference, that.getReference()) && Objects.equals(this.data, that.getData());
     }
 
     @Override

--- a/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
+++ b/src/main/java/com/czertainly/api/model/common/attribute/v2/content/BaseAttributeContent.java
@@ -45,12 +45,11 @@ public class BaseAttributeContent<T> extends AttributeContent {
     @Override
     public boolean equals(Object o) {
         if (o == null) return false;
-        if (this.getClass() != o.getClass()) return false;
         if (this == o) return true;
         BaseAttributeContent<?> that = (BaseAttributeContent<?>) o;
+        boolean referenceEquals = Objects.equals(this.reference, that.getReference());
 
-        if(that.reference == null) return false;
-        return Objects.equals(this.reference, that.reference);
+        return referenceEquals ? Objects.equals(this.data, that.getData()) : referenceEquals;
     }
 
     @Override


### PR DESCRIPTION
equals method of BaseAttributeContent was not working correctly when comparing with specific content type class thus failing in comparison of read only attribute contain with its definition content